### PR TITLE
US-1.1: Create a new form (description, slug, initial draft version)

### DIFF
--- a/server/src/db/migrations/0001_dapper_fallen_one.sql
+++ b/server/src/db/migrations/0001_dapper_fallen_one.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "forms" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "forms" ADD COLUMN "slug" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "forms" ADD CONSTRAINT "forms_slug_unique" UNIQUE("slug");

--- a/server/src/db/migrations/meta/0001_snapshot.json
+++ b/server/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,238 @@
+{
+  "id": "db6b6c7f-dfe1-432c-978c-2b1767eb9621",
+  "prevId": "ca1e28e2-0a6e-4075-8300-584390270e02",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'published') = (\"form_versions\".\"published_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787900717686,
       "tag": "0000_perpetual_mojo",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787902822991,
+      "tag": "0001_dapper_fallen_one",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -16,6 +16,10 @@ import {
 export const forms = pgTable("forms", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull(),
+  description: text("description"),
+  // The stable, human-readable identifier consuming apps use to request this
+  // form (as opposed to `id`, which is an implementation detail).
+  slug: text("slug").notNull().unique(),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/server/src/modules/form-builder/repositories/forms.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/forms.drizzle.ts
@@ -1,23 +1,79 @@
 import { desc } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
-import { forms } from "../../../db/schema.js"
-import type { FormRow, FormsRepository } from "./forms.js"
+import { forms, formVersions } from "../../../db/schema.js"
+import { randomSlugSuffix, slugify } from "../slug.js"
+import type { CreateFormInput, FormRow, FormsRepository } from "./forms.js"
+
+const UNIQUE_VIOLATION = "23505"
+const MAX_SLUG_ATTEMPTS = 5
+
+const FORM_COLUMNS = {
+  id: forms.id,
+  name: forms.name,
+  description: forms.description,
+  slug: forms.slug,
+  createdAt: forms.createdAt,
+}
 
 export class DrizzleFormsRepository implements FormsRepository {
   constructor(private readonly db: Db) {}
 
   async list(): Promise<FormRow[]> {
     return this.db
-      .select({ id: forms.id, name: forms.name, createdAt: forms.createdAt })
+      .select(FORM_COLUMNS)
       .from(forms)
       .orderBy(desc(forms.createdAt))
   }
 
-  async create(name: string): Promise<FormRow> {
-    const [row] = await this.db
-      .insert(forms)
-      .values({ name })
-      .returning({ id: forms.id, name: forms.name, createdAt: forms.createdAt })
-    return row
+  // Creates the form and its initial draft schema version (v0, unpublished)
+  // together, so a form is never left without a version to edit. The slug
+  // starts as a plain slugified name and only gains a random suffix if that
+  // collides, so most forms get a clean, human-readable slug.
+  async create({ name, description }: CreateFormInput): Promise<FormRow> {
+    const baseSlug = slugify(name)
+
+    for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt++) {
+      const slug =
+        attempt === 0 ? baseSlug : `${baseSlug}-${randomSlugSuffix()}`
+
+      try {
+        return await this.db.transaction(async (tx) => {
+          const [row] = await tx
+            .insert(forms)
+            .values({ name, description: description ?? null, slug })
+            .returning(FORM_COLUMNS)
+
+          await tx.insert(formVersions).values({
+            formId: row.id,
+            version: 0,
+            schema: { fields: [] },
+            status: "draft",
+          })
+
+          return row
+        })
+      } catch (error) {
+        const isLastAttempt = attempt === MAX_SLUG_ATTEMPTS - 1
+        if (isUniqueSlugViolation(error) && !isLastAttempt) {
+          continue
+        }
+        throw error
+      }
+    }
+
+    throw new Error("Failed to generate a unique form slug")
   }
+}
+
+function isUniqueSlugViolation(error: unknown): boolean {
+  // drizzle-orm wraps the underlying pg driver error (which carries `code`
+  // and `constraint`) in a DrizzleQueryError's `cause`.
+  const cause =
+    error instanceof Error && error.cause !== undefined ? error.cause : error
+  return (
+    typeof cause === "object" &&
+    cause !== null &&
+    (cause as { code?: string }).code === UNIQUE_VIOLATION &&
+    (cause as { constraint?: string }).constraint === "forms_slug_unique"
+  )
 }

--- a/server/src/modules/form-builder/repositories/forms.ts
+++ b/server/src/modules/form-builder/repositories/forms.ts
@@ -1,10 +1,17 @@
 export interface FormRow {
   id: string
   name: string
+  description: string | null
+  slug: string
   createdAt: Date
+}
+
+export interface CreateFormInput {
+  name: string
+  description?: string | null
 }
 
 export interface FormsRepository {
   list(): Promise<FormRow[]>
-  create(name: string): Promise<FormRow>
+  create(input: CreateFormInput): Promise<FormRow>
 }

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -32,7 +32,7 @@ export function formBuilderPlugin(
         },
       },
       async (request, reply) => {
-        const row = await service.createForm(request.body.name)
+        const row = await service.createForm(request.body)
         return reply
           .code(201)
           .send({ ...row, createdAt: row.createdAt.toISOString() })

--- a/server/src/modules/form-builder/services/form-builder.ts
+++ b/server/src/modules/form-builder/services/form-builder.ts
@@ -1,4 +1,4 @@
-import type { FormsRepository } from "../repositories/forms.js"
+import type { CreateFormInput, FormsRepository } from "../repositories/forms.js"
 
 export class FormBuilderService {
   constructor(private readonly repo: FormsRepository) {}
@@ -7,7 +7,7 @@ export class FormBuilderService {
     return this.repo.list()
   }
 
-  createForm(name: string) {
-    return this.repo.create(name)
+  createForm(input: CreateFormInput) {
+    return this.repo.create(input)
   }
 }

--- a/server/src/modules/form-builder/slug.ts
+++ b/server/src/modules/form-builder/slug.ts
@@ -1,0 +1,21 @@
+import { randomUUID } from "node:crypto"
+
+const COMBINING_DIACRITICS = /[̀-ͯ]/g
+
+// Converts a form name into a URL/lookup-friendly base slug. Not guaranteed
+// unique on its own -- callers append a disambiguating suffix on conflict.
+export function slugify(name: string): string {
+  const base = name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(COMBINING_DIACRITICS, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return base.length > 0 ? base : "form"
+}
+
+// A short, unpredictable suffix used to disambiguate a slug when the base
+// form is already taken, without leaking a sequential counter.
+export function randomSlugSuffix(): string {
+  return randomUUID().slice(0, 8)
+}

--- a/shared/src/schemas/form.ts
+++ b/shared/src/schemas/form.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 export const CreateFormSchema = z.object({
   name: z.string().min(1),
+  description: z.string().min(1).optional(),
 })
 
 export type CreateForm = z.infer<typeof CreateFormSchema>
@@ -9,6 +10,8 @@ export type CreateForm = z.infer<typeof CreateFormSchema>
 export const FormSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
+  description: z.string().nullable(),
+  slug: z.string(),
   createdAt: z.iso.datetime(),
 })
 


### PR DESCRIPTION
## Summary
- `forms` now has `description` (nullable) and a unique `slug` column, with a migration to match.
- `POST /api/forms` accepts an optional `description` and returns `description`/`slug` in the response.
- Creating a form now also inserts the initial `form_versions` row (`version: 0`, `status: draft`, empty field schema) in the same transaction, so a form is never left without a version to edit.
- Slug is generated from the form name; on a unique-slug collision it retries (up to 5 times) with a random suffix.

Closes #1.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran `docker compose up -d`, applied migrations, started the server, and hit `POST /api/forms` live:
  - Fresh form gets a clean slugified slug.
  - Creating a form with a duplicate name gets a random-suffixed slug instead of a 500.
  - Each created form has exactly one `form_versions` row at `version 0` / `draft`.
  - Empty `name` still returns a 400 validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)