### PR TITLE
US-1.2: Publish a form version

### DIFF
--- a/server/src/db/migrations/0002_simple_molecule_man.sql
+++ b/server/src/db/migrations/0002_simple_molecule_man.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "form_versions" DROP CONSTRAINT "form_versions_published_at_matches_status";--> statement-breakpoint
+CREATE UNIQUE INDEX "form_versions_one_published_per_form" ON "form_versions" USING btree ("form_id") WHERE "form_versions"."status" = 'published';--> statement-breakpoint
+ALTER TABLE "form_versions" ADD CONSTRAINT "form_versions_published_at_matches_status" CHECK (("form_versions"."status" = 'draft') = ("form_versions"."published_at" is null));

--- a/server/src/db/migrations/meta/0002_snapshot.json
+++ b/server/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,255 @@
+{
+  "id": "f6112b87-06ad-425c-9d01-21adbeec0d0b",
+  "prevId": "db6b6c7f-dfe1-432c-978c-2b1767eb9621",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1787902822991,
       "tag": "0001_dapper_fallen_one",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1787904121949,
+      "tag": "0002_simple_molecule_man",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   timestamp,
   unique,
+  uniqueIndex,
   check,
 } from "drizzle-orm/pg-core"
 
@@ -43,7 +44,10 @@ export const formVersions = pgTable(
     // shape (see US-0.3, Zod-to-JSON-Schema) rather than a fixed set of
     // columns per field type.
     schema: jsonb("schema").notNull(),
-    status: text("status", { enum: ["draft", "published"] })
+    // "published" is the single active version used for new submissions;
+    // publishing a draft demotes any previously published version to
+    // "superseded" (US-1.2) so it stays retrievable but not editable.
+    status: text("status", { enum: ["draft", "published", "superseded"] })
       .notNull()
       .default("draft"),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -58,8 +62,11 @@ export const formVersions = pgTable(
     ),
     check(
       "form_versions_published_at_matches_status",
-      sql`(${table.status} = 'published') = (${table.publishedAt} is not null)`,
+      sql`(${table.status} = 'draft') = (${table.publishedAt} is null)`,
     ),
+    uniqueIndex("form_versions_one_published_per_form")
+      .on(table.formId)
+      .where(sql`${table.status} = 'published'`),
   ],
 )
 

--- a/server/src/deps.ts
+++ b/server/src/deps.ts
@@ -1,13 +1,19 @@
 import type { Db } from "./db/client.js"
 import { DrizzleFormsRepository } from "./modules/form-builder/repositories/forms.drizzle.js"
+import { DrizzleFormVersionsRepository } from "./modules/form-builder/repositories/form-versions.drizzle.js"
 import { FormBuilderService } from "./modules/form-builder/services/form-builder.js"
+import { FormVersionsService } from "./modules/form-builder/services/form-versions.js"
 
 export interface AppDeps {
   formBuilderService: FormBuilderService
+  formVersionsService: FormVersionsService
 }
 
 export function buildDeps(db: Db): AppDeps {
   return {
     formBuilderService: new FormBuilderService(new DrizzleFormsRepository(db)),
+    formVersionsService: new FormVersionsService(
+      new DrizzleFormVersionsRepository(db),
+    ),
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,9 @@ export function buildApp(deps: AppDeps, logger: Logger) {
   app.setValidatorCompiler(validatorCompiler)
   app.setSerializerCompiler(serializerCompiler)
 
-  app.register(formBuilderPlugin(deps.formBuilderService))
+  app.register(
+    formBuilderPlugin(deps.formBuilderService, deps.formVersionsService),
+  )
 
   return app
 }

--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -1,0 +1,63 @@
+import { and, eq, max } from "drizzle-orm"
+import type { Db } from "../../../db/client.js"
+import { formVersions } from "../../../db/schema.js"
+import {
+  NoDraftVersionError,
+  type FormVersionRow,
+  type FormVersionsRepository,
+} from "./form-versions.js"
+
+const VERSION_COLUMNS = {
+  id: formVersions.id,
+  formId: formVersions.formId,
+  version: formVersions.version,
+  schema: formVersions.schema,
+  status: formVersions.status,
+  createdAt: formVersions.createdAt,
+  publishedAt: formVersions.publishedAt,
+}
+
+export class DrizzleFormVersionsRepository implements FormVersionsRepository {
+  constructor(private readonly db: Db) {}
+
+  async publishDraft(formId: string): Promise<FormVersionRow> {
+    return this.db.transaction(async (tx) => {
+      const [draft] = await tx
+        .select(VERSION_COLUMNS)
+        .from(formVersions)
+        .where(
+          and(eq(formVersions.formId, formId), eq(formVersions.status, "draft")),
+        )
+        .for("update")
+
+      if (!draft) {
+        throw new NoDraftVersionError(formId)
+      }
+
+      const [{ maxVersion }] = await tx
+        .select({ maxVersion: max(formVersions.version) })
+        .from(formVersions)
+        .where(eq(formVersions.formId, formId))
+
+      const nextVersion = (maxVersion ?? 0) + 1
+
+      await tx
+        .update(formVersions)
+        .set({ status: "superseded" })
+        .where(
+          and(
+            eq(formVersions.formId, formId),
+            eq(formVersions.status, "published"),
+          ),
+        )
+
+      const [published] = await tx
+        .update(formVersions)
+        .set({ version: nextVersion, status: "published", publishedAt: new Date() })
+        .where(eq(formVersions.id, draft.id))
+        .returning(VERSION_COLUMNS)
+
+      return published
+    })
+  }
+}

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -1,0 +1,27 @@
+export type FormVersionStatus = "draft" | "published" | "superseded"
+
+export interface FormVersionRow {
+  id: string
+  formId: string
+  version: number
+  schema: unknown
+  status: FormVersionStatus
+  createdAt: Date
+  publishedAt: Date | null
+}
+
+// Thrown when a form has no draft version to publish, either because the
+// form doesn't exist or its only draft was already published.
+export class NoDraftVersionError extends Error {
+  constructor(formId: string) {
+    super(`No draft version found for form ${formId}`)
+    this.name = "NoDraftVersionError"
+  }
+}
+
+export interface FormVersionsRepository {
+  // Publishes the form's current draft version: locks it as immutable,
+  // assigns it the next version number, and supersedes whichever version
+  // was previously active so only one stays active per form (US-1.2).
+  publishDraft(formId: string): Promise<FormVersionRow>
+}

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -1,12 +1,19 @@
 import type { FastifyPluginAsync } from "fastify"
 import type { ZodTypeProvider } from "fastify-type-provider-zod"
-import { CreateFormSchema, FormListSchema, FormSummarySchema } from "shared"
+import { z } from "zod"
+import { CreateFormSchema, FormListSchema, FormSummarySchema, FormVersionSchema } from "shared"
+import { NoDraftVersionError } from "./repositories/form-versions.js"
 import type { FormBuilderService } from "./services/form-builder.js"
+import type { FormVersionsService } from "./services/form-versions.js"
+
+const FormParamsSchema = z.object({ formId: z.string() })
+const ErrorResponseSchema = z.object({ message: z.string() })
 
 // One plugin per capability (US-0.5): everything the form-builder feature
 // exposes over HTTP lives here, mounted once from the app's entry point.
 export function formBuilderPlugin(
   service: FormBuilderService,
+  versionsService: FormVersionsService,
 ): FastifyPluginAsync {
   return async (app) => {
     const typed = app.withTypeProvider<ZodTypeProvider>()
@@ -36,6 +43,33 @@ export function formBuilderPlugin(
         return reply
           .code(201)
           .send({ ...row, createdAt: row.createdAt.toISOString() })
+      },
+    )
+
+    typed.post(
+      "/api/forms/:formId/publish",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: { 200: FormVersionSchema, 409: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const version = await versionsService.publishDraft(
+            request.params.formId,
+          )
+          return reply.code(200).send({
+            ...version,
+            createdAt: version.createdAt.toISOString(),
+            publishedAt: version.publishedAt?.toISOString() ?? null,
+          })
+        } catch (error) {
+          if (error instanceof NoDraftVersionError) {
+            return reply.code(409).send({ message: error.message })
+          }
+          throw error
+        }
       },
     )
   }

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -1,0 +1,9 @@
+import type { FormVersionsRepository } from "../repositories/form-versions.js"
+
+export class FormVersionsService {
+  constructor(private readonly repo: FormVersionsRepository) {}
+
+  publishDraft(formId: string) {
+    return this.repo.publishDraft(formId)
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,3 +4,5 @@ export {
   FormListSchema,
 } from "./schemas/form.js"
 export type { CreateForm, FormSummary } from "./schemas/form.js"
+export { FormVersionSchema } from "./schemas/form-version.js"
+export type { FormVersion } from "./schemas/form-version.js"

--- a/shared/src/schemas/form-version.ts
+++ b/shared/src/schemas/form-version.ts
@@ -1,0 +1,12 @@
+import { z } from "zod"
+
+export const FormVersionSchema = z.object({
+  id: z.string(),
+  formId: z.string(),
+  version: z.number().int(),
+  status: z.enum(["draft", "published", "superseded"]),
+  createdAt: z.iso.datetime(),
+  publishedAt: z.iso.datetime().nullable(),
+})
+
+export type FormVersion = z.infer<typeof FormVersionSchema>


### PR DESCRIPTION
## Summary
- Adds `POST /api/forms/:formId/publish`: publishes the form's current draft version.
- Publishing locks the draft as immutable and assigns it the next sequential version number (1, 2, 3, ...) for that form.
- Whichever version was previously "published" (active) for the form is demoted to "superseded" in the same transaction, so exactly one version stays active at a time.
- Added a partial unique index (`form_versions_one_published_per_form`, on `form_id` where `status = 'published'`) so the "only one active version" invariant is enforced at the database level, not just in application code.
- Returns 409 if the form has no draft version to publish (e.g. it was already published and no new draft exists yet — creating a new draft on edit is #3).

Closes #2.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran against a live Postgres (`docker compose up -d` + migrate + server):
  - Publishing a form's draft returns version 1, status `published`, `publishedAt` set.
  - Publishing again with no draft left returns 409.
  - Inserted a second draft directly and published it: previous version flipped to `superseded`, new version became `published` with the next version number (2).
  - Attempted to force two `published` rows for the same form directly via SQL — rejected by the partial unique index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)