### PR TITLE
US-1.3: Edit a form without affecting live submissions

### DIFF
--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -1,7 +1,8 @@
 import { and, eq, max } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
-import { formVersions } from "../../../db/schema.js"
+import { forms, formVersions } from "../../../db/schema.js"
 import {
+  FormNotFoundError,
   NoDraftVersionError,
   type FormVersionRow,
   type FormVersionsRepository,
@@ -58,6 +59,42 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
         .returning(VERSION_COLUMNS)
 
       return published
+    })
+  }
+
+  async editDraft(formId: string, schema: unknown): Promise<FormVersionRow> {
+    return this.db.transaction(async (tx) => {
+      const [draft] = await tx
+        .select(VERSION_COLUMNS)
+        .from(formVersions)
+        .where(
+          and(eq(formVersions.formId, formId), eq(formVersions.status, "draft")),
+        )
+        .for("update")
+
+      if (draft) {
+        const [updated] = await tx
+          .update(formVersions)
+          .set({ schema })
+          .where(eq(formVersions.id, draft.id))
+          .returning(VERSION_COLUMNS)
+        return updated
+      }
+
+      const [form] = await tx
+        .select({ id: forms.id })
+        .from(forms)
+        .where(eq(forms.id, formId))
+
+      if (!form) {
+        throw new FormNotFoundError(formId)
+      }
+
+      const [created] = await tx
+        .insert(formVersions)
+        .values({ formId, version: 0, schema, status: "draft" })
+        .returning(VERSION_COLUMNS)
+      return created
     })
   }
 }

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -19,9 +19,22 @@ export class NoDraftVersionError extends Error {
   }
 }
 
+export class FormNotFoundError extends Error {
+  constructor(formId: string) {
+    super(`No form found with id ${formId}`)
+    this.name = "FormNotFoundError"
+  }
+}
+
 export interface FormVersionsRepository {
   // Publishes the form's current draft version: locks it as immutable,
   // assigns it the next version number, and supersedes whichever version
   // was previously active so only one stays active per form (US-1.2).
   publishDraft(formId: string): Promise<FormVersionRow>
+
+  // Applies a schema edit to the form's draft version. If the form has no
+  // draft (its active version is published), a new draft is created instead
+  // of mutating the published one, so live submissions keep pointing at the
+  // exact schema they were captured against (US-1.3).
+  editDraft(formId: string, schema: unknown): Promise<FormVersionRow>
 }

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -1,13 +1,33 @@
 import type { FastifyPluginAsync } from "fastify"
 import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import { z } from "zod"
-import { CreateFormSchema, FormListSchema, FormSummarySchema, FormVersionSchema } from "shared"
-import { NoDraftVersionError } from "./repositories/form-versions.js"
+import {
+  CreateFormSchema,
+  FormListSchema,
+  FormSchemaSchema,
+  FormSummarySchema,
+  FormVersionSchema,
+  type FormSchema,
+} from "shared"
+import { FormNotFoundError, NoDraftVersionError } from "./repositories/form-versions.js"
 import type { FormBuilderService } from "./services/form-builder.js"
 import type { FormVersionsService } from "./services/form-versions.js"
 
 const FormParamsSchema = z.object({ formId: z.string() })
 const ErrorResponseSchema = z.object({ message: z.string() })
+
+function serializeVersion<
+  T extends { schema: unknown; createdAt: Date; publishedAt: Date | null },
+>(version: T) {
+  return {
+    ...version,
+    // The jsonb column is untyped at the DB layer; the app is the only
+    // writer and always writes the FormSchema shape.
+    schema: version.schema as FormSchema,
+    createdAt: version.createdAt.toISOString(),
+    publishedAt: version.publishedAt?.toISOString() ?? null,
+  }
+}
 
 // One plugin per capability (US-0.5): everything the form-builder feature
 // exposes over HTTP lives here, mounted once from the app's entry point.
@@ -59,14 +79,35 @@ export function formBuilderPlugin(
           const version = await versionsService.publishDraft(
             request.params.formId,
           )
-          return reply.code(200).send({
-            ...version,
-            createdAt: version.createdAt.toISOString(),
-            publishedAt: version.publishedAt?.toISOString() ?? null,
-          })
+          return reply.code(200).send(serializeVersion(version))
         } catch (error) {
           if (error instanceof NoDraftVersionError) {
             return reply.code(409).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.put(
+      "/api/forms/:formId/draft",
+      {
+        schema: {
+          params: FormParamsSchema,
+          body: FormSchemaSchema,
+          response: { 200: FormVersionSchema, 404: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const version = await versionsService.editDraft(
+            request.params.formId,
+            request.body,
+          )
+          return reply.code(200).send(serializeVersion(version))
+        } catch (error) {
+          if (error instanceof FormNotFoundError) {
+            return reply.code(404).send({ message: error.message })
           }
           throw error
         }

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -6,4 +6,8 @@ export class FormVersionsService {
   publishDraft(formId: string) {
     return this.repo.publishDraft(formId)
   }
+
+  editDraft(formId: string, schema: unknown) {
+    return this.repo.editDraft(formId, schema)
+  }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,5 +4,5 @@ export {
   FormListSchema,
 } from "./schemas/form.js"
 export type { CreateForm, FormSummary } from "./schemas/form.js"
-export { FormVersionSchema } from "./schemas/form-version.js"
-export type { FormVersion } from "./schemas/form-version.js"
+export { FormVersionSchema, FormSchemaSchema } from "./schemas/form-version.js"
+export type { FormVersion, FormSchema } from "./schemas/form-version.js"

--- a/shared/src/schemas/form-version.ts
+++ b/shared/src/schemas/form-version.ts
@@ -1,9 +1,18 @@
 import { z } from "zod"
 
+// The field/layout definition. Loosely typed for now — the concrete field
+// shapes land with the builder-gui epic (US-2.x).
+export const FormSchemaSchema = z.object({
+  fields: z.array(z.unknown()),
+})
+
+export type FormSchema = z.infer<typeof FormSchemaSchema>
+
 export const FormVersionSchema = z.object({
   id: z.string(),
   formId: z.string(),
   version: z.number().int(),
+  schema: FormSchemaSchema,
   status: z.enum(["draft", "published", "superseded"]),
   createdAt: z.iso.datetime(),
   publishedAt: z.iso.datetime().nullable(),


### PR DESCRIPTION
## Summary
- Adds `PUT /api/forms/:formId/draft` to edit a form's field schema.
- If the form already has a draft version, the edit updates that row's `schema` in place.
- If the form's active version is currently `published` (no draft exists), the edit creates a brand-new draft (`version: 0`) instead of touching the published row — the published version's schema is never mutated.
- Existing submissions already reference the exact `form_versions` row they were captured against via `submissions.form_version_id`, and published/superseded rows are never written to after publish, so their schema stays exactly as it was when captured.
- Returns 404 if the form itself doesn't exist.
- `FormVersionSchema` now includes the version's `schema` (`{ fields: [...] }`) in its response, useful for both this endpoint and `/publish`.

Closes #3.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran against a live Postgres (`docker compose up -d` + migrate + server):
  - `PUT .../draft` on a fresh form updates the existing draft (v0) in place.
  - Publishing that draft promotes it to `published`, `version: 1`.
  - `PUT .../draft` again creates a *new* draft row (new id, `version: 0`, `status: draft`) rather than mutating the published row.
  - Verified directly in Postgres that the published row's schema was untouched after the second edit.
  - `PUT .../draft` for a non-existent form returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)