### PR TITLE
US-1.4: View version history

### DIFF
--- a/server/src/db/migrations/0003_stale_major_mapleleaf.sql
+++ b/server/src/db/migrations/0003_stale_major_mapleleaf.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "form_versions" ADD COLUMN "published_by" text;

--- a/server/src/db/migrations/meta/0003_snapshot.json
+++ b/server/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,261 @@
+{
+  "id": "66ce847a-55af-467a-8b83-2b053aef0445",
+  "prevId": "f6112b87-06ad-425c-9d01-21adbeec0d0b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787904121949,
       "tag": "0002_simple_molecule_man",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787905278554,
+      "tag": "0003_stale_major_mapleleaf",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -54,6 +54,10 @@ export const formVersions = pgTable(
       .notNull()
       .defaultNow(),
     publishedAt: timestamp("published_at", { withTimezone: true }),
+    // Freeform identifier of who published this version (US-1.4). There's no
+    // auth/user system yet, so this is whatever the caller supplies rather
+    // than a foreign key to a users table.
+    publishedBy: text("published_by"),
   },
   (table) => [
     unique("form_versions_form_id_version_key").on(

--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -1,4 +1,4 @@
-import { and, eq, max } from "drizzle-orm"
+import { and, desc, eq, max } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
 import { forms, formVersions } from "../../../db/schema.js"
 import {
@@ -16,12 +16,16 @@ const VERSION_COLUMNS = {
   status: formVersions.status,
   createdAt: formVersions.createdAt,
   publishedAt: formVersions.publishedAt,
+  publishedBy: formVersions.publishedBy,
 }
 
 export class DrizzleFormVersionsRepository implements FormVersionsRepository {
   constructor(private readonly db: Db) {}
 
-  async publishDraft(formId: string): Promise<FormVersionRow> {
+  async publishDraft(
+    formId: string,
+    publishedBy?: string | null,
+  ): Promise<FormVersionRow> {
     return this.db.transaction(async (tx) => {
       const [draft] = await tx
         .select(VERSION_COLUMNS)
@@ -54,7 +58,12 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
 
       const [published] = await tx
         .update(formVersions)
-        .set({ version: nextVersion, status: "published", publishedAt: new Date() })
+        .set({
+          version: nextVersion,
+          status: "published",
+          publishedAt: new Date(),
+          publishedBy: publishedBy ?? null,
+        })
         .where(eq(formVersions.id, draft.id))
         .returning(VERSION_COLUMNS)
 
@@ -96,5 +105,22 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
         .returning(VERSION_COLUMNS)
       return created
     })
+  }
+
+  async listVersions(formId: string): Promise<FormVersionRow[]> {
+    const [form] = await this.db
+      .select({ id: forms.id })
+      .from(forms)
+      .where(eq(forms.id, formId))
+
+    if (!form) {
+      throw new FormNotFoundError(formId)
+    }
+
+    return this.db
+      .select(VERSION_COLUMNS)
+      .from(formVersions)
+      .where(eq(formVersions.formId, formId))
+      .orderBy(desc(formVersions.createdAt))
   }
 }

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -8,6 +8,7 @@ export interface FormVersionRow {
   status: FormVersionStatus
   createdAt: Date
   publishedAt: Date | null
+  publishedBy: string | null
 }
 
 // Thrown when a form has no draft version to publish, either because the
@@ -30,11 +31,16 @@ export interface FormVersionsRepository {
   // Publishes the form's current draft version: locks it as immutable,
   // assigns it the next version number, and supersedes whichever version
   // was previously active so only one stays active per form (US-1.2).
-  publishDraft(formId: string): Promise<FormVersionRow>
+  publishDraft(formId: string, publishedBy?: string | null): Promise<FormVersionRow>
 
   // Applies a schema edit to the form's draft version. If the form has no
   // draft (its active version is published), a new draft is created instead
   // of mutating the published one, so live submissions keep pointing at the
   // exact schema they were captured against (US-1.3).
   editDraft(formId: string, schema: unknown): Promise<FormVersionRow>
+
+  // Lists every version of a form (draft, active, and superseded), most
+  // recently created first, so an admin can track changes over time
+  // (US-1.4).
+  listVersions(formId: string): Promise<FormVersionRow[]>
 }

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -6,10 +6,16 @@ import {
   FormListSchema,
   FormSchemaSchema,
   FormSummarySchema,
+  FormVersionHistorySchema,
   FormVersionSchema,
+  PublishFormVersionSchema,
   type FormSchema,
 } from "shared"
-import { FormNotFoundError, NoDraftVersionError } from "./repositories/form-versions.js"
+import {
+  FormNotFoundError,
+  NoDraftVersionError,
+  type FormVersionRow,
+} from "./repositories/form-versions.js"
 import type { FormBuilderService } from "./services/form-builder.js"
 import type { FormVersionsService } from "./services/form-versions.js"
 
@@ -27,6 +33,12 @@ function serializeVersion<
     createdAt: version.createdAt.toISOString(),
     publishedAt: version.publishedAt?.toISOString() ?? null,
   }
+}
+
+// "published" is the DB's name for the single currently-active version; the
+// version-history view (US-1.4) speaks in "active" instead.
+function toHistoryStatus(status: FormVersionRow["status"]) {
+  return status === "published" ? "active" : status
 }
 
 // One plugin per capability (US-0.5): everything the form-builder feature
@@ -71,6 +83,7 @@ export function formBuilderPlugin(
       {
         schema: {
           params: FormParamsSchema,
+          body: PublishFormVersionSchema,
           response: { 200: FormVersionSchema, 409: ErrorResponseSchema },
         },
       },
@@ -78,6 +91,7 @@ export function formBuilderPlugin(
         try {
           const version = await versionsService.publishDraft(
             request.params.formId,
+            request.body.publishedBy,
           )
           return reply.code(200).send(serializeVersion(version))
         } catch (error) {
@@ -105,6 +119,35 @@ export function formBuilderPlugin(
             request.body,
           )
           return reply.code(200).send(serializeVersion(version))
+        } catch (error) {
+          if (error instanceof FormNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/versions",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: { 200: FormVersionHistorySchema, 404: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const versions = await versionsService.listVersions(
+            request.params.formId,
+          )
+          return versions.map((version) => ({
+            id: version.id,
+            version: version.version,
+            status: toHistoryStatus(version.status),
+            publishedAt: version.publishedAt?.toISOString() ?? null,
+            publishedBy: version.publishedBy,
+          }))
         } catch (error) {
           if (error instanceof FormNotFoundError) {
             return reply.code(404).send({ message: error.message })

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -3,8 +3,12 @@ import type { FormVersionsRepository } from "../repositories/form-versions.js"
 export class FormVersionsService {
   constructor(private readonly repo: FormVersionsRepository) {}
 
-  publishDraft(formId: string) {
-    return this.repo.publishDraft(formId)
+  publishDraft(formId: string, publishedBy?: string | null) {
+    return this.repo.publishDraft(formId, publishedBy)
+  }
+
+  listVersions(formId: string) {
+    return this.repo.listVersions(formId)
   }
 
   editDraft(formId: string, schema: unknown) {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,5 +4,16 @@ export {
   FormListSchema,
 } from "./schemas/form.js"
 export type { CreateForm, FormSummary } from "./schemas/form.js"
-export { FormVersionSchema, FormSchemaSchema } from "./schemas/form-version.js"
-export type { FormVersion, FormSchema } from "./schemas/form-version.js"
+export {
+  FormVersionSchema,
+  FormSchemaSchema,
+  PublishFormVersionSchema,
+  FormVersionSummarySchema,
+  FormVersionHistorySchema,
+} from "./schemas/form-version.js"
+export type {
+  FormVersion,
+  FormSchema,
+  PublishFormVersion,
+  FormVersionSummary,
+} from "./schemas/form-version.js"

--- a/shared/src/schemas/form-version.ts
+++ b/shared/src/schemas/form-version.ts
@@ -16,6 +16,34 @@ export const FormVersionSchema = z.object({
   status: z.enum(["draft", "published", "superseded"]),
   createdAt: z.iso.datetime(),
   publishedAt: z.iso.datetime().nullable(),
+  publishedBy: z.string().nullable(),
 })
 
 export type FormVersion = z.infer<typeof FormVersionSchema>
+
+// A request with no body at all (publishedBy is optional) arrives as `null`
+// rather than `undefined` once Fastify's JSON body parser runs, so an empty
+// body is normalized to `{}` before validating the shape.
+export const PublishFormVersionSchema = z.preprocess(
+  (value) => value ?? {},
+  z.object({
+    publishedBy: z.string().min(1).optional(),
+  }),
+)
+
+export type PublishFormVersion = z.infer<typeof PublishFormVersionSchema>
+
+// The version-history view (US-1.4) speaks in "active" rather than
+// "published" — the DB's "published" status always means the single
+// currently-active version, so the two terms mean the same thing here.
+export const FormVersionSummarySchema = z.object({
+  id: z.string(),
+  version: z.number().int(),
+  status: z.enum(["draft", "active", "superseded"]),
+  publishedAt: z.iso.datetime().nullable(),
+  publishedBy: z.string().nullable(),
+})
+
+export type FormVersionSummary = z.infer<typeof FormVersionSummarySchema>
+
+export const FormVersionHistorySchema = z.array(FormVersionSummarySchema)


### PR DESCRIPTION
## Summary
- Adds `GET /api/forms/:formId/versions`, listing every version of a form (most recently created first) with its version number, publish date, publisher, and status.
- Status is reported as `draft` / `active` / `superseded` (per the AC's wording) — this maps directly from the DB's `draft` / `published` / `superseded` enum, where `published` always means the single currently-active version.
- Returns 404 for a form that doesn't exist.
- Added a `published_by` column to `form_versions` and threaded an optional `publishedBy` through `POST /api/forms/:formId/publish`'s request body, storing it against the version.

**Scope note:** there's no auth/user system in this app yet, so "published by" can't be derived from a logged-in user — it's a freeform identifier the caller supplies at publish time. This is the pragmatic stand-in until an auth epic exists; happy to revisit once one does.

Closes #4.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran against a live Postgres (`docker compose up -d` + migrate + server):
  - `GET .../versions` on a fresh form shows one `draft` entry.
  - Publishing with `{"publishedBy": "richard@example.com"}` stores and returns it; the version list then shows that version as `active` with the publisher and publish date.
  - Publishing with **no request body at all** still works (`publishedBy: null`) — caught and fixed a real bug here where Fastify parses an empty POST body as `null` rather than `undefined`, which broke validation against the new optional-body schema; fixed by preprocessing `null`/`undefined` to `{}` before validating.
  - `GET .../versions` for a non-existent form returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)