### PR TITLE
US-2.1: Add a field via drag and drop

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "client",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "-w", "client"],
+      "port": 5173
+    }
+  ]
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,0 +1,70 @@
+body {
+  font-family: system-ui, sans-serif;
+  margin: 2rem;
+}
+
+.form-builder__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form-builder__workspace {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.field-palette {
+  flex: 0 0 12rem;
+}
+
+.field-palette__item {
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #f9f9f9;
+  cursor: grab;
+  list-style: none;
+}
+
+.form-canvas {
+  flex: 1;
+  min-height: 12rem;
+  border: 2px dashed #ccc;
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.form-canvas__empty {
+  color: #888;
+}
+
+.form-canvas__fields {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.form-canvas__field {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.form-canvas__field-type {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #888;
+}
+
+.form-canvas__drop-indicator {
+  height: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 2px;
+  background: #4a90d9;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,26 +1,56 @@
 import { useEffect, useState } from "react"
 import type { FormSummary } from "shared"
+import { createForm, listForms } from "./api.js"
+import { FormBuilder } from "./FormBuilder.js"
 
-// Placeholder view proving the client can reach the form-builder Fastify
-// plugin end to end (US-0.5). The real form-building UI lands with US-1.x.
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
+  const [selected, setSelected] = useState<FormSummary | null>(null)
 
   useEffect(() => {
-    fetch("/api/forms")
-      .then((res) => res.json())
+    listForms()
       .then(setForms)
       .catch(() => setForms([]))
   }, [])
+
+  if (selected) {
+    return (
+      <FormBuilder
+        formId={selected.id}
+        formName={selected.name}
+        onBack={() => setSelected(null)}
+      />
+    )
+  }
 
   return (
     <main>
       <h1>form-builder</h1>
       <ul>
         {forms.map((form) => (
-          <li key={form.id}>{form.name}</li>
+          <li key={form.id}>
+            <button type="button" onClick={() => setSelected(form)}>
+              {form.name}
+            </button>
+          </li>
         ))}
       </ul>
+      <NewFormButton onCreated={(form) => setForms([form, ...forms])} />
     </main>
+  )
+}
+
+function NewFormButton({ onCreated }: { onCreated: (form: FormSummary) => void }) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        const name = window.prompt("Form name?")
+        if (!name) return
+        createForm(name).then(onCreated)
+      }}
+    >
+      New form
+    </button>
   )
 }

--- a/client/src/FieldPalette.tsx
+++ b/client/src/FieldPalette.tsx
@@ -1,0 +1,32 @@
+import { FIELD_TYPES, FIELD_TYPE_LABELS, type FieldType } from "shared"
+import { FIELD_TYPE_DRAG_KEY } from "./dnd.js"
+
+// The list of field types an admin can drag onto the canvas (US-2.1). Each
+// type's own configuration options land with the field-types epic (US-3.x).
+export function FieldPalette() {
+  return (
+    <aside className="field-palette">
+      <h2>Field types</h2>
+      <ul>
+        {FIELD_TYPES.map((type) => (
+          <PaletteItem key={type} type={type} />
+        ))}
+      </ul>
+    </aside>
+  )
+}
+
+function PaletteItem({ type }: { type: FieldType }) {
+  return (
+    <li
+      className="field-palette__item"
+      draggable
+      onDragStart={(event) => {
+        event.dataTransfer.setData(FIELD_TYPE_DRAG_KEY, type)
+        event.dataTransfer.effectAllowed = "copy"
+      }}
+    >
+      {FIELD_TYPE_LABELS[type]}
+    </li>
+  )
+}

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react"
+import { FIELD_TYPE_LABELS, type Field, type FieldType } from "shared"
+import { getDraft, saveDraft } from "./api.js"
+import { FieldPalette } from "./FieldPalette.js"
+import { FormCanvas } from "./FormCanvas.js"
+
+interface FormBuilderProps {
+  formId: string
+  formName: string
+  onBack: () => void
+}
+
+// Loads the form's current draft, then lets an admin drag field types from
+// the palette onto the canvas to build it visually (US-2.1).
+export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
+  const [fields, setFields] = useState<Field[]>([])
+  const [status, setStatus] = useState<"loading" | "ready" | "error">(
+    "loading",
+  )
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getDraft(formId)
+      .then((draft) => {
+        if (cancelled) return
+        setFields(draft?.schema.fields ?? [])
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId])
+
+  function handleDrop(type: FieldType, index: number) {
+    const field: Field = {
+      id: crypto.randomUUID(),
+      type,
+      label: FIELD_TYPE_LABELS[type],
+    }
+    const next = [...fields.slice(0, index), field, ...fields.slice(index)]
+    setFields(next)
+    setSaveError(null)
+    saveDraft(formId, next).catch(() => {
+      setSaveError("Couldn't save this change — it may not persist.")
+    })
+  }
+
+  return (
+    <main className="form-builder">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName}</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && <p role="alert">Couldn't load this form.</p>}
+      {saveError && <p role="alert">{saveError}</p>}
+
+      {status === "ready" && (
+        <div className="form-builder__workspace">
+          <FieldPalette />
+          <FormCanvas fields={fields} onDrop={handleDrop} />
+        </div>
+      )}
+    </main>
+  )
+}

--- a/client/src/FormCanvas.tsx
+++ b/client/src/FormCanvas.tsx
@@ -1,0 +1,94 @@
+import { useRef, useState } from "react"
+import { FIELD_TYPE_LABELS, FieldTypeSchema, type Field, type FieldType } from "shared"
+import { FIELD_TYPE_DRAG_KEY } from "./dnd.js"
+
+interface FormCanvasProps {
+  fields: Field[]
+  onDrop: (type: FieldType, index: number) => void
+}
+
+// The drop target for the field palette (US-2.1). Tracks where in the
+// field list the cursor currently sits so a field lands exactly at the
+// drop position rather than always at the end.
+export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
+  const [dropIndex, setDropIndex] = useState<number | null>(null)
+  const listRef = useRef<HTMLOListElement>(null)
+
+  function indexForPointer(clientY: number): number {
+    const items = listRef.current?.querySelectorAll<HTMLElement>(
+      "[data-field-item]",
+    )
+    if (!items) return fields.length
+
+    for (let i = 0; i < items.length; i++) {
+      const rect = items[i].getBoundingClientRect()
+      if (clientY < rect.top + rect.height / 2) {
+        return i
+      }
+    }
+    return fields.length
+  }
+
+  function isFieldDrag(event: React.DragEvent) {
+    return event.dataTransfer.types.includes(FIELD_TYPE_DRAG_KEY)
+  }
+
+  return (
+    <section
+      className="form-canvas"
+      onDragOver={(event) => {
+        if (!isFieldDrag(event)) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = "copy"
+        setDropIndex(indexForPointer(event.clientY))
+      }}
+      onDragLeave={(event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node)) return
+        setDropIndex(null)
+      }}
+      onDrop={(event) => {
+        if (!isFieldDrag(event)) return
+        event.preventDefault()
+        const parsed = FieldTypeSchema.safeParse(
+          event.dataTransfer.getData(FIELD_TYPE_DRAG_KEY),
+        )
+        if (parsed.success) {
+          // Computed fresh rather than read from `dropIndex` state: the
+          // last dragover's setDropIndex may not have flushed yet by the
+          // time drop fires, so the state can still be stale here.
+          onDrop(parsed.data, indexForPointer(event.clientY))
+        }
+        setDropIndex(null)
+      }}
+    >
+      <h2>Form canvas</h2>
+      {fields.length === 0 && dropIndex === null && (
+        <p className="form-canvas__empty">
+          Drag a field type here to add it to the form.
+        </p>
+      )}
+      <ol className="form-canvas__fields" ref={listRef}>
+        {fields.map((field, index) => (
+          <li key={field.id}>
+            {dropIndex === index && <DropIndicator />}
+            <div className="form-canvas__field" data-field-item>
+              <span className="form-canvas__field-type">
+                {FIELD_TYPE_LABELS[field.type]}
+              </span>
+              <span className="form-canvas__field-label">{field.label}</span>
+            </div>
+          </li>
+        ))}
+        {dropIndex === fields.length && (
+          <li>
+            <DropIndicator />
+          </li>
+        )}
+      </ol>
+    </section>
+  )
+}
+
+function DropIndicator() {
+  return <div className="form-canvas__drop-indicator" />
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,0 +1,38 @@
+import type { Field, FormSchema, FormSummary, FormVersion } from "shared"
+
+async function json<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export function listForms(): Promise<FormSummary[]> {
+  return fetch("/api/forms").then((res) => json<FormSummary[]>(res))
+}
+
+export function createForm(name: string): Promise<FormSummary> {
+  return fetch("/api/forms", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  }).then((res) => json<FormSummary>(res))
+}
+
+export function getDraft(formId: string): Promise<FormVersion | null> {
+  return fetch(`/api/forms/${formId}/draft`).then((res) =>
+    json<FormVersion | null>(res),
+  )
+}
+
+export function saveDraft(
+  formId: string,
+  fields: Field[],
+): Promise<FormVersion> {
+  const body: FormSchema = { fields }
+  return fetch(`/api/forms/${formId}/draft`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then((res) => json<FormVersion>(res))
+}

--- a/client/src/dnd.ts
+++ b/client/src/dnd.ts
@@ -1,0 +1,3 @@
+// Shared drag payload key between the palette (source) and the canvas
+// (target), using the native HTML5 drag-and-drop API.
+export const FIELD_TYPE_DRAG_KEY = "application/x-formbuilder-field-type"

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { App } from "./App.js"
+import "./App.css"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -123,4 +123,28 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
       .where(eq(formVersions.formId, formId))
       .orderBy(desc(formVersions.createdAt))
   }
+
+  async getDraft(formId: string): Promise<FormVersionRow | null> {
+    const [draft] = await this.db
+      .select(VERSION_COLUMNS)
+      .from(formVersions)
+      .where(
+        and(eq(formVersions.formId, formId), eq(formVersions.status, "draft")),
+      )
+
+    if (draft) {
+      return draft
+    }
+
+    const [form] = await this.db
+      .select({ id: forms.id })
+      .from(forms)
+      .where(eq(forms.id, formId))
+
+    if (!form) {
+      throw new FormNotFoundError(formId)
+    }
+
+    return null
+  }
 }

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -43,4 +43,10 @@ export interface FormVersionsRepository {
   // recently created first, so an admin can track changes over time
   // (US-1.4).
   listVersions(formId: string): Promise<FormVersionRow[]>
+
+  // Returns the form's current draft, or null if the form exists but has no
+  // draft (its active version is published and untouched since). Throws if
+  // the form itself doesn't exist. Lets the builder UI resume editing
+  // whatever was last saved (US-2.1).
+  getDraft(formId: string): Promise<FormVersionRow | null>
 }

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -129,6 +129,34 @@ export function formBuilderPlugin(
     )
 
     typed.get(
+      "/api/forms/:formId/draft",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: {
+            200: FormVersionSchema.nullable(),
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const version = await versionsService.getDraft(
+            request.params.formId,
+          )
+          return reply
+            .code(200)
+            .send(version ? serializeVersion(version) : null)
+        } catch (error) {
+          if (error instanceof FormNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
       "/api/forms/:formId/versions",
       {
         schema: {

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -14,4 +14,8 @@ export class FormVersionsService {
   editDraft(formId: string, schema: unknown) {
     return this.repo.editDraft(formId, schema)
   }
+
+  getDraft(formId: string) {
+    return this.repo.getDraft(formId)
+  }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -17,3 +17,10 @@ export type {
   PublishFormVersion,
   FormVersionSummary,
 } from "./schemas/form-version.js"
+export {
+  FieldSchema,
+  FieldTypeSchema,
+  FIELD_TYPES,
+  FIELD_TYPE_LABELS,
+} from "./schemas/field.js"
+export type { Field, FieldType } from "./schemas/field.js"

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+// Only the types needed to make the drag-and-drop canvas work end to end
+// (US-2.1). Per-type configuration (max length, options list, required
+// flag, ...) lands with their own field-types epic issues.
+export const FieldTypeSchema = z.enum(["text", "textarea", "dropdown"])
+
+export type FieldType = z.infer<typeof FieldTypeSchema>
+
+export const FIELD_TYPES: readonly FieldType[] = [
+  "text",
+  "textarea",
+  "dropdown",
+]
+
+export const FIELD_TYPE_LABELS: Record<FieldType, string> = {
+  text: "Text",
+  textarea: "Text area",
+  dropdown: "Dropdown",
+}
+
+export const FieldSchema = z.object({
+  id: z.string(),
+  type: FieldTypeSchema,
+  label: z.string(),
+})
+
+export type Field = z.infer<typeof FieldSchema>

--- a/shared/src/schemas/form-version.ts
+++ b/shared/src/schemas/form-version.ts
@@ -1,9 +1,9 @@
 import { z } from "zod"
+import { FieldSchema } from "./field.js"
 
-// The field/layout definition. Loosely typed for now — the concrete field
-// shapes land with the builder-gui epic (US-2.x).
+// The field/layout definition.
 export const FormSchemaSchema = z.object({
-  fields: z.array(z.unknown()),
+  fields: z.array(FieldSchema),
 })
 
 export type FormSchema = z.infer<typeof FormSchemaSchema>


### PR DESCRIPTION
## Summary
- Adds a builder UI: a field-type palette an admin can drag onto a form canvas, dropping a field at the exact position among the existing fields (native HTML5 drag-and-drop, no new runtime dependency).
- The change is saved immediately to the form's draft via the existing `PUT /api/forms/:formId/draft`.
- Clicking a form in the list now opens this builder instead of just being a static list item.

**Scope note:** the field-types epic (#10–#14) isn't built yet, so the palette offers a minimal set — `text`, `textarea`, `dropdown` — with just an `id`/`type`/`label`, no per-type configuration (max length, options, required flag, etc.). Those land with their own issues; this issue is about the drag-and-drop mechanism working end to end.

Backend additions needed to make the builder usable:
- `GET /api/forms/:formId/draft` — returns the form's current draft (or `null` if its active version is published with no pending edit), so reopening the builder resumes whatever was last saved instead of starting blank. 404s if the form itself doesn't exist.
- `FormSchemaSchema`'s `fields` is now a concrete `Field` shape (`{ id, type, label }`) instead of `unknown[]`.
- Added `.claude/launch.json` so the client dev server can be previewed with the `run` skill / `preview_start`.

Closes #5.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client) and exercised the UI directly:
  - Opening a form shows the palette and an empty-state canvas.
  - Dispatching a real drag-and-drop (dragstart → dragover → drop with a `DataTransfer`) from a palette item onto the canvas adds that field, and it persists (`GET .../draft` reflects it).
  - Dropping a second field near the **top** of an existing field correctly inserts it **before** — found and fixed a real race here: `onDrop` was reading `dropIndex` React state set by the prior `dragover`, which hadn't necessarily flushed yet, so it always fell back to "append at end". Fixed by computing the drop index directly from the drop event's coordinates instead of relying on that state.
  - Dropping near the bottom appends correctly; final order verified via `GET .../draft`.
  - Reloaded the page and confirmed the builder resumes with the previously-saved fields in the right order (via `GET .../draft`), rather than starting blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)