### PR TITLE
US-2.2: Reorder fields

### DIFF
--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -10,8 +10,21 @@ interface FormBuilderProps {
   onBack: () => void
 }
 
+// Moves the field at sourceIndex so it ends up at targetIndex, where
+// targetIndex is expressed in terms of the list *before* the move (as
+// produced by the canvas's drop-position calculation).
+function reorder(fields: Field[], sourceIndex: number, targetIndex: number) {
+  const next = [...fields]
+  const [moved] = next.splice(sourceIndex, 1)
+  const adjustedTarget =
+    targetIndex > sourceIndex ? targetIndex - 1 : targetIndex
+  next.splice(adjustedTarget, 0, moved)
+  return next
+}
+
 // Loads the form's current draft, then lets an admin drag field types from
-// the palette onto the canvas to build it visually (US-2.1).
+// the palette onto the canvas to build it visually (US-2.1), and drag
+// existing fields to reorder them (US-2.2).
 export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
   const [fields, setFields] = useState<Field[]>([])
   const [status, setStatus] = useState<"loading" | "ready" | "error">(
@@ -36,18 +49,27 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     }
   }, [formId])
 
+  function persist(next: Field[]) {
+    setFields(next)
+    setSaveError(null)
+    saveDraft(formId, next).catch(() => {
+      setSaveError("Couldn't save this change — it may not persist.")
+    })
+  }
+
   function handleDrop(type: FieldType, index: number) {
     const field: Field = {
       id: crypto.randomUUID(),
       type,
       label: FIELD_TYPE_LABELS[type],
     }
-    const next = [...fields.slice(0, index), field, ...fields.slice(index)]
-    setFields(next)
-    setSaveError(null)
-    saveDraft(formId, next).catch(() => {
-      setSaveError("Couldn't save this change — it may not persist.")
-    })
+    persist([...fields.slice(0, index), field, ...fields.slice(index)])
+  }
+
+  function handleReorder(fieldId: string, index: number) {
+    const sourceIndex = fields.findIndex((field) => field.id === fieldId)
+    if (sourceIndex === -1) return
+    persist(reorder(fields, sourceIndex, index))
   }
 
   return (
@@ -66,7 +88,11 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
       {status === "ready" && (
         <div className="form-builder__workspace">
           <FieldPalette />
-          <FormCanvas fields={fields} onDrop={handleDrop} />
+          <FormCanvas
+            fields={fields}
+            onDrop={handleDrop}
+            onReorder={handleReorder}
+          />
         </div>
       )}
     </main>

--- a/client/src/FormCanvas.tsx
+++ b/client/src/FormCanvas.tsx
@@ -1,17 +1,20 @@
 import { useRef, useState } from "react"
 import { FIELD_TYPE_LABELS, FieldTypeSchema, type Field, type FieldType } from "shared"
-import { FIELD_TYPE_DRAG_KEY } from "./dnd.js"
+import { FIELD_REORDER_DRAG_KEY, FIELD_TYPE_DRAG_KEY } from "./dnd.js"
 
 interface FormCanvasProps {
   fields: Field[]
   onDrop: (type: FieldType, index: number) => void
+  onReorder: (fieldId: string, index: number) => void
 }
 
-// The drop target for the field palette (US-2.1). Tracks where in the
-// field list the cursor currently sits so a field lands exactly at the
-// drop position rather than always at the end.
-export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
+// The drop target for the field palette (US-2.1) and for reordering fields
+// already on the canvas (US-2.2). Tracks where in the field list the
+// cursor currently sits so a field lands exactly at the drop position
+// rather than always at the end.
+export function FormCanvas({ fields, onDrop, onReorder }: FormCanvasProps) {
   const [dropIndex, setDropIndex] = useState<number | null>(null)
+  const [draggingId, setDraggingId] = useState<string | null>(null)
   const listRef = useRef<HTMLOListElement>(null)
 
   function indexForPointer(clientY: number): number {
@@ -29,17 +32,21 @@ export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
     return fields.length
   }
 
-  function isFieldDrag(event: React.DragEvent) {
+  function isNewFieldDrag(event: React.DragEvent) {
     return event.dataTransfer.types.includes(FIELD_TYPE_DRAG_KEY)
+  }
+
+  function isReorderDrag(event: React.DragEvent) {
+    return event.dataTransfer.types.includes(FIELD_REORDER_DRAG_KEY)
   }
 
   return (
     <section
       className="form-canvas"
       onDragOver={(event) => {
-        if (!isFieldDrag(event)) return
+        if (!isNewFieldDrag(event) && !isReorderDrag(event)) return
         event.preventDefault()
-        event.dataTransfer.dropEffect = "copy"
+        event.dataTransfer.dropEffect = isReorderDrag(event) ? "move" : "copy"
         setDropIndex(indexForPointer(event.clientY))
       }}
       onDragLeave={(event) => {
@@ -47,16 +54,21 @@ export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
         setDropIndex(null)
       }}
       onDrop={(event) => {
-        if (!isFieldDrag(event)) return
-        event.preventDefault()
-        const parsed = FieldTypeSchema.safeParse(
-          event.dataTransfer.getData(FIELD_TYPE_DRAG_KEY),
-        )
-        if (parsed.success) {
-          // Computed fresh rather than read from `dropIndex` state: the
-          // last dragover's setDropIndex may not have flushed yet by the
-          // time drop fires, so the state can still be stale here.
-          onDrop(parsed.data, indexForPointer(event.clientY))
+        // Computed fresh rather than read from `dropIndex` state: the last
+        // dragover's setDropIndex may not have flushed yet by the time drop
+        // fires, so the state can still be stale here.
+        const index = indexForPointer(event.clientY)
+
+        if (isReorderDrag(event)) {
+          event.preventDefault()
+          const fieldId = event.dataTransfer.getData(FIELD_REORDER_DRAG_KEY)
+          if (fieldId) onReorder(fieldId, index)
+        } else if (isNewFieldDrag(event)) {
+          event.preventDefault()
+          const parsed = FieldTypeSchema.safeParse(
+            event.dataTransfer.getData(FIELD_TYPE_DRAG_KEY),
+          )
+          if (parsed.success) onDrop(parsed.data, index)
         }
         setDropIndex(null)
       }}
@@ -71,7 +83,18 @@ export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
         {fields.map((field, index) => (
           <li key={field.id}>
             {dropIndex === index && <DropIndicator />}
-            <div className="form-canvas__field" data-field-item>
+            <div
+              className="form-canvas__field"
+              data-field-item
+              draggable
+              style={{ opacity: draggingId === field.id ? 0.4 : 1 }}
+              onDragStart={(event) => {
+                event.dataTransfer.setData(FIELD_REORDER_DRAG_KEY, field.id)
+                event.dataTransfer.effectAllowed = "move"
+                setDraggingId(field.id)
+              }}
+              onDragEnd={() => setDraggingId(null)}
+            >
               <span className="form-canvas__field-type">
                 {FIELD_TYPE_LABELS[field.type]}
               </span>

--- a/client/src/dnd.ts
+++ b/client/src/dnd.ts
@@ -1,3 +1,8 @@
 // Shared drag payload key between the palette (source) and the canvas
 // (target), using the native HTML5 drag-and-drop API.
 export const FIELD_TYPE_DRAG_KEY = "application/x-formbuilder-field-type"
+
+// Drag payload key for reordering a field already on the canvas (US-2.2),
+// distinct from FIELD_TYPE_DRAG_KEY so the canvas can tell "new field from
+// the palette" apart from "move this existing field".
+export const FIELD_REORDER_DRAG_KEY = "application/x-formbuilder-field-id"


### PR DESCRIPTION
## Summary
- Existing fields on the canvas (added in #5) are now draggable, so an admin can drag a field to a new position among the others.
- Reuses the same drop-position calculation as adding a new field from the palette, using a separate drag-payload key (`FIELD_REORDER_DRAG_KEY`) so the canvas can tell a palette drag apart from a reorder drag.
- The reordered list is saved to the draft immediately via the existing `PUT /api/forms/:formId/draft`.

Closes #6.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client), seeded a form with 3 fields (First, Second, Third), and exercised real drag-and-drop via dispatched `DragEvent`s:
  - Dragging the last field ("Third") to the top moved it there — result: Third, First, Second — verified against `GET .../draft`.
  - Dragging the now-middle field ("First") to the bottom moved it there — result: Third, Second, First — verified against `GET .../draft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)