### PR TITLE
US-3.1: Text field

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -54,6 +54,12 @@ body {
   margin-bottom: 0.5rem;
   border: 1px solid #ddd;
   border-radius: 4px;
+  cursor: pointer;
+}
+
+.form-canvas__field--selected {
+  border-color: #4a90d9;
+  box-shadow: 0 0 0 1px #4a90d9;
 }
 
 .form-canvas__field-type {
@@ -67,4 +73,35 @@ body {
   margin-bottom: 0.5rem;
   border-radius: 2px;
   background: #4a90d9;
+}
+
+.field-inspector {
+  flex: 0 0 14rem;
+}
+
+.field-inspector__empty {
+  color: #888;
+}
+
+.field-inspector__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.field-inspector__field input {
+  padding: 0.375rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.field-inspector__field--checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.field-inspector__field--checkbox input {
+  width: auto;
 }

--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -1,0 +1,81 @@
+import type { Field } from "shared"
+
+interface FieldInspectorProps {
+  field: Field | null
+  onChange: (field: Field) => void
+}
+
+// Configuration panel for the field selected on the canvas. Only "text"
+// has type-specific options so far (US-3.1); other types grow their own
+// as their field-types epic issues land.
+export function FieldInspector({ field, onChange }: FieldInspectorProps) {
+  if (!field) {
+    return (
+      <aside className="field-inspector">
+        <h2>Field settings</h2>
+        <p className="field-inspector__empty">
+          Select a field on the canvas to configure it.
+        </p>
+      </aside>
+    )
+  }
+
+  return (
+    <aside className="field-inspector">
+      <h2>Field settings</h2>
+      <label className="field-inspector__field">
+        Label
+        <input
+          type="text"
+          value={field.label}
+          onChange={(event) =>
+            onChange({ ...field, label: event.target.value })
+          }
+        />
+      </label>
+
+      {field.type === "text" && (
+        <>
+          <label className="field-inspector__field">
+            Placeholder
+            <input
+              type="text"
+              value={field.placeholder ?? ""}
+              onChange={(event) =>
+                onChange({
+                  ...field,
+                  placeholder: event.target.value || undefined,
+                })
+              }
+            />
+          </label>
+          <label className="field-inspector__field field-inspector__field--checkbox">
+            <input
+              type="checkbox"
+              checked={field.required}
+              onChange={(event) =>
+                onChange({ ...field, required: event.target.checked })
+              }
+            />
+            Required
+          </label>
+          <label className="field-inspector__field">
+            Max length
+            <input
+              type="number"
+              min={1}
+              value={field.maxLength ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  maxLength: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+        </>
+      )}
+    </aside>
+  )
+}

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { FIELD_TYPE_LABELS, type Field, type FieldType } from "shared"
 import { getDraft, saveDraft } from "./api.js"
+import { FieldInspector } from "./FieldInspector.js"
 import { FieldPalette } from "./FieldPalette.js"
 import { FormCanvas } from "./FormCanvas.js"
 
@@ -10,10 +11,25 @@ interface FormBuilderProps {
   onBack: () => void
 }
 
+function createField(type: FieldType): Field {
+  const id = crypto.randomUUID()
+  const label = FIELD_TYPE_LABELS[type]
+  switch (type) {
+    case "text":
+      return { id, type, label, required: false }
+    case "textarea":
+      return { id, type, label }
+    case "dropdown":
+      return { id, type, label }
+  }
+}
+
 // Loads the form's current draft, then lets an admin drag field types from
-// the palette onto the canvas to build it visually (US-2.1).
+// the palette onto the canvas to build it visually (US-2.1), reorder them
+// (US-2.2), and configure the selected field (US-3.x).
 export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
   const [fields, setFields] = useState<Field[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
   const [status, setStatus] = useState<"loading" | "ready" | "error">(
     "loading",
   )
@@ -36,19 +52,25 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     }
   }, [formId])
 
-  function handleDrop(type: FieldType, index: number) {
-    const field: Field = {
-      id: crypto.randomUUID(),
-      type,
-      label: FIELD_TYPE_LABELS[type],
-    }
-    const next = [...fields.slice(0, index), field, ...fields.slice(index)]
+  function persist(next: Field[]) {
     setFields(next)
     setSaveError(null)
     saveDraft(formId, next).catch(() => {
       setSaveError("Couldn't save this change — it may not persist.")
     })
   }
+
+  function handleDrop(type: FieldType, index: number) {
+    const field = createField(type)
+    persist([...fields.slice(0, index), field, ...fields.slice(index)])
+    setSelectedId(field.id)
+  }
+
+  function handleFieldChange(next: Field) {
+    persist(fields.map((field) => (field.id === next.id ? next : field)))
+  }
+
+  const selectedField = fields.find((field) => field.id === selectedId) ?? null
 
   return (
     <main className="form-builder">
@@ -66,7 +88,13 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
       {status === "ready" && (
         <div className="form-builder__workspace">
           <FieldPalette />
-          <FormCanvas fields={fields} onDrop={handleDrop} />
+          <FormCanvas
+            fields={fields}
+            selectedId={selectedId}
+            onDrop={handleDrop}
+            onSelect={setSelectedId}
+          />
+          <FieldInspector field={selectedField} onChange={handleFieldChange} />
         </div>
       )}
     </main>

--- a/client/src/FormCanvas.tsx
+++ b/client/src/FormCanvas.tsx
@@ -4,13 +4,21 @@ import { FIELD_TYPE_DRAG_KEY } from "./dnd.js"
 
 interface FormCanvasProps {
   fields: Field[]
+  selectedId: string | null
   onDrop: (type: FieldType, index: number) => void
+  onSelect: (id: string) => void
 }
 
 // The drop target for the field palette (US-2.1). Tracks where in the
 // field list the cursor currently sits so a field lands exactly at the
-// drop position rather than always at the end.
-export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
+// drop position rather than always at the end. Clicking a field selects
+// it for configuration in the inspector (US-3.1).
+export function FormCanvas({
+  fields,
+  selectedId,
+  onDrop,
+  onSelect,
+}: FormCanvasProps) {
   const [dropIndex, setDropIndex] = useState<number | null>(null)
   const listRef = useRef<HTMLOListElement>(null)
 
@@ -71,7 +79,16 @@ export function FormCanvas({ fields, onDrop }: FormCanvasProps) {
         {fields.map((field, index) => (
           <li key={field.id}>
             {dropIndex === index && <DropIndicator />}
-            <div className="form-canvas__field" data-field-item>
+            <div
+              className={
+                "form-canvas__field" +
+                (field.id === selectedId
+                  ? " form-canvas__field--selected"
+                  : "")
+              }
+              data-field-item
+              onClick={() => onSelect(field.id)}
+            >
               <span className="form-canvas__field-type">
                 {FIELD_TYPE_LABELS[field.type]}
               </span>

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -20,7 +20,10 @@ export type {
 export {
   FieldSchema,
   FieldTypeSchema,
+  TextFieldSchema,
+  TextAreaFieldSchema,
+  DropdownFieldSchema,
   FIELD_TYPES,
   FIELD_TYPE_LABELS,
 } from "./schemas/field.js"
-export type { Field, FieldType } from "./schemas/field.js"
+export type { Field, FieldType, TextField } from "./schemas/field.js"

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -1,8 +1,8 @@
 import { z } from "zod"
 
-// Only the types needed to make the drag-and-drop canvas work end to end
-// (US-2.1). Per-type configuration (max length, options list, required
-// flag, ...) lands with their own field-types epic issues.
+// Per-type configuration lands as each field-types epic issue is built.
+// This is a discriminated union (per US-3.4's "extensible type registry")
+// so a new type/config can be added without touching the others.
 export const FieldTypeSchema = z.enum(["text", "textarea", "dropdown"])
 
 export type FieldType = z.infer<typeof FieldTypeSchema>
@@ -19,10 +19,36 @@ export const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   dropdown: "Dropdown",
 }
 
-export const FieldSchema = z.object({
+// US-3.1: a single-line text field, configurable beyond just its label.
+export const TextFieldSchema = z.object({
   id: z.string(),
-  type: FieldTypeSchema,
+  type: z.literal("text"),
+  label: z.string(),
+  placeholder: z.string().optional(),
+  required: z.boolean().default(false),
+  maxLength: z.number().int().positive().optional(),
+})
+
+export type TextField = z.infer<typeof TextFieldSchema>
+
+// Not yet configurable beyond a label — their own field-types epic issues
+// (US-3.2, US-3.3) extend these.
+export const TextAreaFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("textarea"),
   label: z.string(),
 })
+
+export const DropdownFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("dropdown"),
+  label: z.string(),
+})
+
+export const FieldSchema = z.discriminatedUnion("type", [
+  TextFieldSchema,
+  TextAreaFieldSchema,
+  DropdownFieldSchema,
+])
 
 export type Field = z.infer<typeof FieldSchema>


### PR DESCRIPTION
## Summary
- `Field` is now a Zod discriminated union by `type` (per US-3.4's "extensible type registry" goal) instead of one flat shape, so each field type's configuration can grow independently without affecting the others.
- The `text` field type gains real configuration: `label`, `placeholder`, `required`, `maxLength`.
- `textarea` and `dropdown` keep their minimal `{ id, type, label }` shape for now — their own field-types epic issues (#11, #12) extend those.
- Clicking a field on the canvas now selects it (visually highlighted), and a new **field settings** inspector panel lets you edit the selected field's config. Changes save immediately through the existing `PUT /api/forms/:formId/draft`.

Closes #10.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client):
  - Dragged a "Text" field onto the canvas — it's auto-selected and the inspector shows Label/Placeholder/Required/Max length.
  - Edited all four fields via the UI (label → "Full name", placeholder → "e.g. Jane Doe", checked Required, max length → 100).
  - Verified via `GET .../draft` that all four values persisted correctly: `{"type":"text","label":"Full name","placeholder":"e.g. Jane Doe","required":true,"maxLength":100}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)