### PR TITLE
US-0.2: Select and integrate JSON Schema form renderer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@jsonforms/core": "^3.8.0",
+    "@jsonforms/react": "^3.8.0",
+    "@jsonforms/vanilla-renderers": "^3.8.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "shared": "*"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,16 +2,29 @@ import { useEffect, useState } from "react"
 import type { FormSummary } from "shared"
 import { createForm, listForms } from "./api.js"
 import { FormBuilder } from "./FormBuilder.js"
+import { RendererSpike } from "./renderer-spike/RendererSpike.js"
 
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
   const [selected, setSelected] = useState<FormSummary | null>(null)
+  const [showRendererSpike, setShowRendererSpike] = useState(false)
 
   useEffect(() => {
     listForms()
       .then(setForms)
       .catch(() => setForms([]))
   }, [])
+
+  if (showRendererSpike) {
+    return (
+      <main>
+        <button type="button" onClick={() => setShowRendererSpike(false)}>
+          ← Back
+        </button>
+        <RendererSpike />
+      </main>
+    )
+  }
 
   if (selected) {
     return (
@@ -36,6 +49,11 @@ export function App() {
         ))}
       </ul>
       <NewFormButton onCreated={(form) => setForms([form, ...forms])} />
+      <p>
+        <button type="button" onClick={() => setShowRendererSpike(true)}>
+          View renderer spike (US-0.2)
+        </button>
+      </p>
     </main>
   )
 }

--- a/client/src/renderer-spike/RendererSpike.tsx
+++ b/client/src/renderer-spike/RendererSpike.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+
+// US-0.2 spike: proves a JSON Schema-driven renderer can render a form
+// built from the field types the canvas currently supports (US-3.1/3.2/3.3)
+// without any hand-written form markup. The schema/uiSchema below are
+// hand-written stand-ins for what US-0.3's Zod-to-JSON-Schema conversion
+// will eventually generate from `shared`'s FieldSchema — this component
+// only exercises the renderer, not that conversion step.
+const schema = {
+  type: "object",
+  properties: {
+    fullName: {
+      type: "string",
+      title: "Full name",
+      maxLength: 80,
+    },
+    bio: {
+      type: "string",
+      title: "Bio",
+    },
+    favoriteColor: {
+      type: "string",
+      title: "Favorite color",
+      enum: ["Red", "Green", "Blue"],
+    },
+  },
+  required: ["fullName"],
+}
+
+const uiSchema = {
+  type: "VerticalLayout",
+  elements: [
+    { type: "Control", scope: "#/properties/fullName" },
+    {
+      type: "Control",
+      scope: "#/properties/bio",
+      options: { multi: true },
+    },
+    { type: "Control", scope: "#/properties/favoriteColor" },
+  ],
+}
+
+const renderers = [...vanillaRenderers]
+
+export function RendererSpike() {
+  const [data, setData] = useState<Record<string, unknown>>({})
+
+  return (
+    <div className="renderer-spike">
+      <h2>JSON Forms renderer spike (US-0.2)</h2>
+      <p>
+        Renders a text field, a text area, and a dropdown from a JSON Schema
+        + UI Schema — no hand-coded form markup.
+      </p>
+      <JsonForms
+        schema={schema}
+        uischema={uiSchema}
+        data={data}
+        renderers={renderers}
+        cells={vanillaCells}
+        onChange={({ data }) => setData(data)}
+      />
+      <h3>Live data</h3>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  )
+}

--- a/docs/adr/0003-json-schema-renderer.md
+++ b/docs/adr/0003-json-schema-renderer.md
@@ -1,0 +1,66 @@
+# ADR-0003: JSON Schema-driven form renderer
+
+## Status
+
+Accepted
+
+## Context
+
+form-builder needs to render a form from its schema (`FormSchema` /
+`Field[]` in `shared`) without hand-coding a component per field type, so
+Epic 3's field types (US-3.1–3.5) plug into rendering the same way they
+plug into the builder canvas. The two realistic JSON Schema-driven React
+renderers are JSON Forms (`@jsonforms/react`) and RJSF
+(`react-jsonschema-form` / `@rjsf/core`).
+
+- Both consume a JSON Schema for data shape/validation. JSON Forms adds a
+  separate UI Schema for layout and widget choice per field; RJSF instead
+  layers `uiSchema` options onto the same JSON Schema tree. The separate UI
+  Schema is a closer fit for this project: the builder's field
+  configuration (label, placeholder, required, per-type options) is
+  naturally a layout/presentation concern distinct from the JSON Schema
+  that US-0.3 will generate from `shared`'s Zod field schemas, so the two
+  can be generated independently instead of interleaving builder-specific
+  options into the data schema.
+- JSON Forms registers renderers as `(tester, renderer)` pairs, where a
+  tester scores how well a renderer matches a given schema/UI Schema
+  fragment. That maps directly onto `field.ts`'s "extensible type registry"
+  design (adding a field type there means adding a matching JSON Forms
+  renderer, without touching existing ones). RJSF's equivalent is naming a
+  custom `widget` in `uiSchema`, which works but is a naming convention
+  rather than a scored match, and doesn't compose as cleanly for
+  discriminated-union-shaped fields like `dropdown` (needs an
+  `enum`-specific renderer) versus `textarea` (needs a `multi`-line text
+  renderer) coexisting with the plain `text` renderer.
+- JSON Forms ships a dependency-free `vanilla-renderers` set (plain HTML
+  controls, no UI kit required), which fits form-builder's plain-CSS
+  styling; RJSF's core theme is also framework-free but its more complete
+  themes pull in Bootstrap or Material UI, which this project does not use
+  elsewhere.
+- Both support React 19 as installed here.
+
+## Decision
+
+Use **JSON Forms** (`@jsonforms/core`, `@jsonforms/react`,
+`@jsonforms/vanilla-renderers`) as the form renderer.
+
+A spike (`client/src/renderer-spike/RendererSpike.tsx`, reachable from the
+"View renderer spike" button on the forms list) proves it against a
+hand-written sample schema covering all three field types the canvas
+currently supports: `text` (plain string control), `textarea` (string
+control with the `multi` UI Schema option), and `dropdown` (string `enum`
+control). The schema/UI Schema pair there stand in for what US-0.3's
+Zod-to-JSON-Schema conversion will generate; this spike only exercises the
+renderer itself.
+
+## Consequences
+
+- `client/package.json` depends on `@jsonforms/core`, `@jsonforms/react`,
+  and `@jsonforms/vanilla-renderers`.
+- Rendering a live form (Epic 4) will generate a JSON Schema + UI Schema
+  pair from `shared`'s `FormSchema`/`Field` types (per US-0.3) and pass them
+  to `<JsonForms>` with the vanilla renderer set, rather than hand-writing a
+  component per field type.
+- A new field type (US-3.4 onward) needs a matching JSON Forms renderer
+  (tester + renderer pair) registered alongside the vanilla set, mirroring
+  how it plugs into the builder's canvas and palette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
     "client": {
       "version": "0.0.0",
       "dependencies": {
+        "@jsonforms/core": "^3.8.0",
+        "@jsonforms/react": "^3.8.0",
+        "@jsonforms/vanilla-renderers": "^3.8.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "shared": "*"
@@ -603,6 +606,62 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsonforms/core": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-3.8.0.tgz",
+      "integrity": "sha512-XSvaZuQSs/MceG5nDDcrE879onPHkGBy0xEuLeZMUkSM/M8wc1dEUrJtMOZVNSITocm9YXFY1qQ5gnsPP38zAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.3",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^2.1.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@jsonforms/core/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jsonforms/react": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@jsonforms/react/-/react-3.8.0.tgz",
+      "integrity": "sha512-k81+yWLpCQl+3XizS1bLjXoBwYhW1OAkjSXFA8W5qNtfPZjSOXDgtiuMOGYDv4b60tu2e9RB8h2P2O7QhfkhiA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@jsonforms/core": "3.8.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@jsonforms/vanilla-renderers": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@jsonforms/vanilla-renderers/-/vanilla-renderers-3.8.0.tgz",
+      "integrity": "sha512-s75TG4hSYgYLN9IRVhYtGjijqyhVXijgDhb2WnMqY+Ki7MQkLn9U7yg/l89NEpwzWS1sv0DxKUxriqVUq382og==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@jsonforms/core": "3.8.0",
+        "@jsonforms/react": "3.8.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
@@ -1075,6 +1134,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2063,6 +2128,12 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {


### PR DESCRIPTION
## Summary
- Evaluates JSON Forms against RJSF and records the decision in `docs/adr/0003-json-schema-renderer.md`
- Adds `@jsonforms/core`, `@jsonforms/react`, `@jsonforms/vanilla-renderers` to the client
- Adds a spike (`client/src/renderer-spike/RendererSpike.tsx`) proving the renderer against a sample schema covering all three field types the canvas currently supports (text, textarea, dropdown), reachable via a "View renderer spike" button on the forms list

Closes #22

## Test plan
- [x] `npm run typecheck`
- [x] Ran the client dev server, opened the renderer spike, confirmed text/textarea/dropdown controls render and bind data correctly