### PR TITLE
US-3.5: Mark a field as required

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -105,3 +105,32 @@ body {
 .field-inspector__field--checkbox input {
   width: auto;
 }
+
+.form-canvas__field-required-badge {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: #4a90d9;
+  white-space: nowrap;
+}
+
+.form-list__item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-fill__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  max-width: 24rem;
+}
+
+.form-fill__field input,
+.form-fill__field textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,10 +2,16 @@ import { useEffect, useState } from "react"
 import type { FormSummary } from "shared"
 import { createForm, listForms } from "./api.js"
 import { FormBuilder } from "./FormBuilder.js"
+import { FormFill } from "./FormFill.js"
+
+type View =
+  | { mode: "list" }
+  | { mode: "build"; form: FormSummary }
+  | { mode: "fill"; form: FormSummary }
 
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
-  const [selected, setSelected] = useState<FormSummary | null>(null)
+  const [view, setView] = useState<View>({ mode: "list" })
 
   useEffect(() => {
     listForms()
@@ -13,12 +19,22 @@ export function App() {
       .catch(() => setForms([]))
   }, [])
 
-  if (selected) {
+  if (view.mode === "build") {
     return (
       <FormBuilder
-        formId={selected.id}
-        formName={selected.name}
-        onBack={() => setSelected(null)}
+        formId={view.form.id}
+        formName={view.form.name}
+        onBack={() => setView({ mode: "list" })}
+      />
+    )
+  }
+
+  if (view.mode === "fill") {
+    return (
+      <FormFill
+        formId={view.form.id}
+        formName={view.form.name}
+        onBack={() => setView({ mode: "list" })}
       />
     )
   }
@@ -28,9 +44,13 @@ export function App() {
       <h1>form-builder</h1>
       <ul>
         {forms.map((form) => (
-          <li key={form.id}>
-            <button type="button" onClick={() => setSelected(form)}>
-              {form.name}
+          <li key={form.id} className="form-list__item">
+            <span>{form.name}</span>
+            <button type="button" onClick={() => setView({ mode: "build", form })}>
+              Build
+            </button>
+            <button type="button" onClick={() => setView({ mode: "fill", form })}>
+              Fill out
             </button>
           </li>
         ))}

--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -5,9 +5,10 @@ interface FieldInspectorProps {
   onChange: (field: Field) => void
 }
 
-// Configuration panel for the field selected on the canvas. Only "text"
-// has type-specific options so far (US-3.1); other types grow their own
-// as their field-types epic issues land.
+// Configuration panel for the field selected on the canvas. Label and
+// required apply to every field type (US-3.5); type-specific options
+// (like "text"'s placeholder/maxLength, US-3.1) grow as their own
+// field-types epic issues land.
 export function FieldInspector({ field, onChange }: FieldInspectorProps) {
   if (!field) {
     return (
@@ -33,6 +34,16 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
           }
         />
       </label>
+      <label className="field-inspector__field field-inspector__field--checkbox">
+        <input
+          type="checkbox"
+          checked={field.required}
+          onChange={(event) =>
+            onChange({ ...field, required: event.target.checked })
+          }
+        />
+        Required
+      </label>
 
       {field.type === "text" && (
         <>
@@ -48,16 +59,6 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
                 })
               }
             />
-          </label>
-          <label className="field-inspector__field field-inspector__field--checkbox">
-            <input
-              type="checkbox"
-              checked={field.required}
-              onChange={(event) =>
-                onChange({ ...field, required: event.target.checked })
-              }
-            />
-            Required
           </label>
           <label className="field-inspector__field">
             Max length

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -30,15 +30,16 @@ function createField(type: FieldType): Field {
     case "text":
       return { id, type, label, required: false }
     case "textarea":
-      return { id, type, label }
+      return { id, type, label, required: false }
     case "dropdown":
-      return { id, type, label }
+      return { id, type, label, required: false }
   }
 }
 
 // Loads the form's current draft, then lets an admin drag field types from
 // the palette onto the canvas to build it visually (US-2.1), reorder them
-// (US-2.2), and configure the selected field (US-3.x).
+// (US-2.2), and configure the selected field — including marking it
+// required (US-3.1, US-3.5).
 export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
   const [fields, setFields] = useState<Field[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)

--- a/client/src/FormCanvas.tsx
+++ b/client/src/FormCanvas.tsx
@@ -114,6 +114,11 @@ export function FormCanvas({
                 {FIELD_TYPE_LABELS[field.type]}
               </span>
               <span className="form-canvas__field-label">{field.label}</span>
+              {field.required && (
+                <span className="form-canvas__field-required-badge">
+                  Required
+                </span>
+              )}
             </div>
           </li>
         ))}

--- a/client/src/FormFill.tsx
+++ b/client/src/FormFill.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react"
+import type { Field, FormVersion } from "shared"
+import { getActiveVersion, SubmissionRejectedError, submitForm } from "./api.js"
+
+interface FormFillProps {
+  formId: string
+  formName: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "no-active" | "error" | "submitted"
+
+// The public-facing view a respondent fills out. Required fields are
+// enforced two ways: natively via HTML `required` here, and again by the
+// server at submission time in case that's ever bypassed (US-3.5).
+export function FormFill({ formId, formName, onBack }: FormFillProps) {
+  const [version, setVersion] = useState<FormVersion | null>(null)
+  const [status, setStatus] = useState<Status>("loading")
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getActiveVersion(formId)
+      .then((active) => {
+        if (cancelled) return
+        setVersion(active)
+        setStatus(active ? "ready" : "no-active")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmitError(null)
+    const data: Record<string, unknown> = {}
+    new FormData(event.currentTarget).forEach((value, key) => {
+      data[key] = value
+    })
+    try {
+      await submitForm(formId, data)
+      setStatus("submitted")
+    } catch (error) {
+      if (error instanceof SubmissionRejectedError) {
+        setSubmitError("Please fill out all required fields.")
+      } else {
+        setSubmitError("Couldn't submit this form. Please try again.")
+      }
+    }
+  }
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName}</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && <p role="alert">Couldn't load this form.</p>}
+      {status === "no-active" && (
+        <p role="alert">This form hasn't been published yet.</p>
+      )}
+      {status === "submitted" && <p>Thanks — your response was recorded.</p>}
+      {submitError && <p role="alert">{submitError}</p>}
+
+      {status === "ready" && version && (
+        <form onSubmit={handleSubmit}>
+          {version.schema.fields.map((field) => (
+            <FieldInput key={field.id} field={field} />
+          ))}
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    </main>
+  )
+}
+
+function FieldInput({ field }: { field: Field }) {
+  return (
+    <label className="form-fill__field">
+      {field.label}
+      {field.required && <span aria-hidden="true"> *</span>}
+      {field.type === "textarea" ? (
+        <textarea name={field.id} required={field.required} />
+      ) : field.type === "text" ? (
+        <input
+          type="text"
+          name={field.id}
+          required={field.required}
+          placeholder={field.placeholder}
+          maxLength={field.maxLength}
+        />
+      ) : (
+        <input type="text" name={field.id} required={field.required} />
+      )}
+    </label>
+  )
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,4 +1,11 @@
-import type { Field, FormSchema, FormSummary, FormVersion } from "shared"
+import type {
+  Field,
+  FormSchema,
+  FormSummary,
+  FormVersion,
+  Submission,
+  SubmissionValidationError,
+} from "shared"
 
 async function json<T>(res: Response): Promise<T> {
   if (!res.ok) {
@@ -35,4 +42,36 @@ export function saveDraft(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   }).then((res) => json<FormVersion>(res))
+}
+
+export function getActiveVersion(formId: string): Promise<FormVersion | null> {
+  return fetch(`/api/forms/${formId}/active`).then((res) =>
+    json<FormVersion | null>(res),
+  )
+}
+
+// Thrown when the server rejects a submission for missing required fields
+// (US-3.5) — a defense-in-depth check behind the form's own client-side
+// `required` validation.
+export class SubmissionRejectedError extends Error {
+  constructor(public readonly missingFieldIds: string[]) {
+    super("Some required fields are missing")
+    this.name = "SubmissionRejectedError"
+  }
+}
+
+export async function submitForm(
+  formId: string,
+  data: Record<string, unknown>,
+): Promise<Submission> {
+  const res = await fetch(`/api/forms/${formId}/submissions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ data }),
+  })
+  if (res.status === 400) {
+    const body = (await res.json()) as SubmissionValidationError
+    throw new SubmissionRejectedError(body.missingFieldIds)
+  }
+  return json<Submission>(res)
 }

--- a/server/src/deps.ts
+++ b/server/src/deps.ts
@@ -3,17 +3,25 @@ import { DrizzleFormsRepository } from "./modules/form-builder/repositories/form
 import { DrizzleFormVersionsRepository } from "./modules/form-builder/repositories/form-versions.drizzle.js"
 import { FormBuilderService } from "./modules/form-builder/services/form-builder.js"
 import { FormVersionsService } from "./modules/form-builder/services/form-versions.js"
+import { DrizzleSubmissionsRepository } from "./modules/submissions/repositories/submissions.drizzle.js"
+import { SubmissionsService } from "./modules/submissions/services/submissions.js"
 
 export interface AppDeps {
   formBuilderService: FormBuilderService
   formVersionsService: FormVersionsService
+  submissionsService: SubmissionsService
 }
 
 export function buildDeps(db: Db): AppDeps {
+  const formVersionsService = new FormVersionsService(
+    new DrizzleFormVersionsRepository(db),
+  )
   return {
     formBuilderService: new FormBuilderService(new DrizzleFormsRepository(db)),
-    formVersionsService: new FormVersionsService(
-      new DrizzleFormVersionsRepository(db),
+    formVersionsService,
+    submissionsService: new SubmissionsService(
+      formVersionsService,
+      new DrizzleSubmissionsRepository(db),
     ),
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from "fastify-type-provider-zod"
 import type { Logger } from "pino"
 import { formBuilderPlugin } from "./modules/form-builder/routes.js"
+import { submissionsPlugin } from "./modules/submissions/routes.js"
 import type { AppDeps } from "./deps.js"
 
 export function buildApp(deps: AppDeps, logger: Logger) {
@@ -16,6 +17,7 @@ export function buildApp(deps: AppDeps, logger: Logger) {
   app.register(
     formBuilderPlugin(deps.formBuilderService, deps.formVersionsService),
   )
+  app.register(submissionsPlugin(deps.submissionsService))
 
   return app
 }

--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -147,4 +147,31 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
 
     return null
   }
+
+  async getActiveVersion(formId: string): Promise<FormVersionRow | null> {
+    const [active] = await this.db
+      .select(VERSION_COLUMNS)
+      .from(formVersions)
+      .where(
+        and(
+          eq(formVersions.formId, formId),
+          eq(formVersions.status, "published"),
+        ),
+      )
+
+    if (active) {
+      return active
+    }
+
+    const [form] = await this.db
+      .select({ id: forms.id })
+      .from(forms)
+      .where(eq(forms.id, formId))
+
+    if (!form) {
+      throw new FormNotFoundError(formId)
+    }
+
+    return null
+  }
 }

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -49,4 +49,10 @@ export interface FormVersionsRepository {
   // the form itself doesn't exist. Lets the builder UI resume editing
   // whatever was last saved (US-2.1).
   getDraft(formId: string): Promise<FormVersionRow | null>
+
+  // Returns the form's currently active (published) version, or null if
+  // nothing has been published yet. Throws if the form itself doesn't
+  // exist. This is what a submission is validated and recorded against
+  // (US-3.5).
+  getActiveVersion(formId: string): Promise<FormVersionRow | null>
 }

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -157,6 +157,34 @@ export function formBuilderPlugin(
     )
 
     typed.get(
+      "/api/forms/:formId/active",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: {
+            200: FormVersionSchema.nullable(),
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const version = await versionsService.getActiveVersion(
+            request.params.formId,
+          )
+          return reply
+            .code(200)
+            .send(version ? serializeVersion(version) : null)
+        } catch (error) {
+          if (error instanceof FormNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
       "/api/forms/:formId/versions",
       {
         schema: {

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -18,4 +18,8 @@ export class FormVersionsService {
   getDraft(formId: string) {
     return this.repo.getDraft(formId)
   }
+
+  getActiveVersion(formId: string) {
+    return this.repo.getActiveVersion(formId)
+  }
 }

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,0 +1,26 @@
+import type { Db } from "../../../db/client.js"
+import { submissions } from "../../../db/schema.js"
+import type { SubmissionRow, SubmissionsRepository } from "./submissions.js"
+
+export class DrizzleSubmissionsRepository implements SubmissionsRepository {
+  constructor(private readonly db: Db) {}
+
+  async create(formVersionId: string, data: unknown): Promise<SubmissionRow> {
+    const [row] = await this.db
+      .insert(submissions)
+      .values({
+        formVersionId,
+        data,
+        status: "submitted",
+        submittedAt: new Date(),
+      })
+      .returning({
+        id: submissions.id,
+        formVersionId: submissions.formVersionId,
+        submittedAt: submissions.submittedAt,
+      })
+    // submittedAt is nullable at the column level (a submission can be
+    // saved as a draft first), but this insert always sets it.
+    return { ...row, submittedAt: row.submittedAt! }
+  }
+}

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -1,0 +1,11 @@
+export interface SubmissionRow {
+  id: string
+  formVersionId: string
+  submittedAt: Date
+}
+
+export interface SubmissionsRepository {
+  // Records a completed submission against a specific form version, so it
+  // always points at the exact schema it was captured against (US-1.3).
+  create(formVersionId: string, data: unknown): Promise<SubmissionRow>
+}

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -1,0 +1,64 @@
+import type { FastifyPluginAsync } from "fastify"
+import type { ZodTypeProvider } from "fastify-type-provider-zod"
+import { z } from "zod"
+import {
+  SubmissionSchema,
+  SubmissionValidationErrorSchema,
+  SubmitFormSchema,
+} from "shared"
+import {
+  MissingRequiredFieldsError,
+  NoActiveVersionError,
+} from "./services/submissions.js"
+import type { SubmissionsService } from "./services/submissions.js"
+
+const FormParamsSchema = z.object({ formId: z.string() })
+const ErrorResponseSchema = z.object({ message: z.string() })
+
+// One plugin per capability (US-0.5): submitting a completed form against
+// its active version.
+export function submissionsPlugin(
+  service: SubmissionsService,
+): FastifyPluginAsync {
+  return async (app) => {
+    const typed = app.withTypeProvider<ZodTypeProvider>()
+
+    typed.post(
+      "/api/forms/:formId/submissions",
+      {
+        schema: {
+          params: FormParamsSchema,
+          body: SubmitFormSchema,
+          response: {
+            201: SubmissionSchema,
+            400: SubmissionValidationErrorSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const submission = await service.submit(
+            request.params.formId,
+            request.body.data,
+          )
+          return reply.code(201).send({
+            ...submission,
+            submittedAt: submission.submittedAt.toISOString(),
+          })
+        } catch (error) {
+          if (error instanceof MissingRequiredFieldsError) {
+            return reply.code(400).send({
+              message: error.message,
+              missingFieldIds: error.missingFieldIds,
+            })
+          }
+          if (error instanceof NoActiveVersionError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+  }
+}

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -1,0 +1,49 @@
+import type { Field } from "shared"
+import type { FormVersionsService } from "../../form-builder/services/form-versions.js"
+import type { SubmissionsRepository } from "../repositories/submissions.js"
+
+export class NoActiveVersionError extends Error {
+  constructor(formId: string) {
+    super(`No active version to submit against for form ${formId}`)
+    this.name = "NoActiveVersionError"
+  }
+}
+
+export class MissingRequiredFieldsError extends Error {
+  constructor(public readonly missingFieldIds: string[]) {
+    super(`Missing required fields: ${missingFieldIds.join(", ")}`)
+    this.name = "MissingRequiredFieldsError"
+  }
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === undefined || value === null || value === ""
+}
+
+export class SubmissionsService {
+  constructor(
+    private readonly formVersions: FormVersionsService,
+    private readonly repo: SubmissionsRepository,
+  ) {}
+
+  // Validates the submission against the form's active version before
+  // recording it, so a required field can never be silently skipped even
+  // if a client bypasses its own validation (US-3.5).
+  async submit(formId: string, data: Record<string, unknown>) {
+    const active = await this.formVersions.getActiveVersion(formId)
+    if (!active) {
+      throw new NoActiveVersionError(formId)
+    }
+
+    const fields = (active.schema as { fields: Field[] }).fields
+    const missingFieldIds = fields
+      .filter((field) => field.required && isEmpty(data[field.id]))
+      .map((field) => field.id)
+
+    if (missingFieldIds.length > 0) {
+      throw new MissingRequiredFieldsError(missingFieldIds)
+    }
+
+    return this.repo.create(active.id, data)
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,3 +27,13 @@ export {
   FIELD_TYPE_LABELS,
 } from "./schemas/field.js"
 export type { Field, FieldType, TextField } from "./schemas/field.js"
+export {
+  SubmitFormSchema,
+  SubmissionSchema,
+  SubmissionValidationErrorSchema,
+} from "./schemas/submission.js"
+export type {
+  SubmitForm,
+  Submission,
+  SubmissionValidationError,
+} from "./schemas/submission.js"

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -19,30 +19,36 @@ export const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   dropdown: "Dropdown",
 }
 
+// Any field type can be marked required (US-3.5); per-type configuration
+// beyond that (max length, options list, ...) lands with their own issues.
+const requiredFlag = z.boolean().default(false)
+
 // US-3.1: a single-line text field, configurable beyond just its label.
 export const TextFieldSchema = z.object({
   id: z.string(),
   type: z.literal("text"),
   label: z.string(),
   placeholder: z.string().optional(),
-  required: z.boolean().default(false),
+  required: requiredFlag,
   maxLength: z.number().int().positive().optional(),
 })
 
 export type TextField = z.infer<typeof TextFieldSchema>
 
-// Not yet configurable beyond a label — their own field-types epic issues
-// (US-3.2, US-3.3) extend these.
+// Not yet configurable beyond a label and required — their own field-types
+// epic issues (US-3.2, US-3.3) extend these.
 export const TextAreaFieldSchema = z.object({
   id: z.string(),
   type: z.literal("textarea"),
   label: z.string(),
+  required: requiredFlag,
 })
 
 export const DropdownFieldSchema = z.object({
   id: z.string(),
   type: z.literal("dropdown"),
   label: z.string(),
+  required: requiredFlag,
 })
 
 export const FieldSchema = z.discriminatedUnion("type", [

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+// Submitted values keyed by field id. Loosely typed for now, matching
+// FormSchemaSchema's own field looseness ahead of the full field-types
+// epic.
+export const SubmitFormSchema = z.object({
+  data: z.record(z.string(), z.unknown()),
+})
+
+export type SubmitForm = z.infer<typeof SubmitFormSchema>
+
+export const SubmissionSchema = z.object({
+  id: z.string(),
+  formVersionId: z.string(),
+  submittedAt: z.iso.datetime(),
+})
+
+export type Submission = z.infer<typeof SubmissionSchema>
+
+// Returned when required fields are missing at submission time (US-3.5).
+export const SubmissionValidationErrorSchema = z.object({
+  message: z.string(),
+  missingFieldIds: z.array(z.string()),
+})
+
+export type SubmissionValidationError = z.infer<
+  typeof SubmissionValidationErrorSchema
+>


### PR DESCRIPTION
## Summary
- The **Required** checkbox in the field inspector is now universal to every field type (previously "text"-only from #10), so any field — text, textarea, or dropdown — can be marked required.
- Adds the minimal submission path needed to actually enforce it end to end, since no submission feature existed yet:
  - `GET /api/forms/:formId/active` — the form's live/published version, for rendering a public fill-out form.
  - A new **Fill out** view (`FormFill.tsx`) rendering the active version as a real HTML form. Required fields get the native `required` attribute, so the browser blocks submission client-side for free — no validation library needed.
  - `POST /api/forms/:formId/submissions` — independently validates the submission against the active version's required fields before recording it, so a bypassed/absent client check can never skip enforcement. Returns 400 with the missing field ids if any required field is empty, 404 if the form has no active version yet.
- The form list now has separate **Build** and **Fill out** buttons per form.

**Scope note:** there's no dedicated submission epic/issues yet, so this is a deliberately minimal slice — no draft-submissions, no per-type validation beyond "present and non-empty" (e.g. no numeric/date rules), and no dropdown option list (that's #12, not built). Happy to revisit once a submissions epic exists.

Closes #14.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client) against the merged `#6`/`#10` code:
  - Server-side: submitted directly via `curl` with a required field missing → `400` with `missingFieldIds`; with it present → `201` and a row landed in `submissions`.
  - UI: dragged a Text and a Text area field onto the canvas; selected the Text area and checked **Required** in the inspector — persisted (`GET .../draft` shows `"required":true`).
  - Published the form, opened **Fill out**: the required Text area rendered with `required` and a `*`; clicking Submit with it empty correctly failed native browser validation (`checkValidity() === false`, "Please fill out this field."); filling it in and submitting succeeded and recorded the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)