### PR TITLE
US-3.3: Dropdown field

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -105,3 +105,23 @@ body {
 .field-inspector__field--checkbox input {
   width: auto;
 }
+
+.field-inspector__options {
+  list-style: none;
+  margin: 0.25rem 0;
+  padding: 0;
+}
+
+.field-inspector__option {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.field-inspector__option input {
+  min-width: 0;
+  flex: 1;
+  padding: 0.25rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -1,13 +1,13 @@
-import type { Field } from "shared"
+import type { DropdownOption, Field } from "shared"
 
 interface FieldInspectorProps {
   field: Field | null
   onChange: (field: Field) => void
 }
 
-// Configuration panel for the field selected on the canvas. Only "text"
-// has type-specific options so far (US-3.1); other types grow their own
-// as their field-types epic issues land.
+// Configuration panel for the field selected on the canvas. "text" and
+// "dropdown" have type-specific options so far (US-3.1, US-3.3); other
+// types grow their own as their field-types epic issues land.
 export function FieldInspector({ field, onChange }: FieldInspectorProps) {
   if (!field) {
     return (
@@ -76,6 +76,144 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
           </label>
         </>
       )}
+
+      {field.type === "dropdown" && (
+        <>
+          <label className="field-inspector__field field-inspector__field--checkbox">
+            <input
+              type="checkbox"
+              checked={field.required}
+              onChange={(event) =>
+                onChange({ ...field, required: event.target.checked })
+              }
+            />
+            Required
+          </label>
+
+          <div className="field-inspector__field">
+            Options
+            <ul className="field-inspector__options">
+              {field.options.map((option, index) => (
+                <li key={index} className="field-inspector__option">
+                  <input
+                    type="text"
+                    placeholder="Label"
+                    value={option.label}
+                    onChange={(event) => {
+                      const options = replaceOption(field.options, index, {
+                        ...option,
+                        label: event.target.value,
+                      })
+                      onChange({ ...field, options })
+                    }}
+                  />
+                  <input
+                    type="text"
+                    placeholder="Value"
+                    value={option.value}
+                    onChange={(event) => {
+                      const options = replaceOption(field.options, index, {
+                        ...option,
+                        value: event.target.value,
+                      })
+                      onChange({ ...field, options })
+                    }}
+                  />
+                  <button
+                    type="button"
+                    disabled={index === 0}
+                    onClick={() =>
+                      onChange({
+                        ...field,
+                        options: moveOption(field.options, index, index - 1),
+                      })
+                    }
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    disabled={index === field.options.length - 1}
+                    onClick={() =>
+                      onChange({
+                        ...field,
+                        options: moveOption(field.options, index, index + 1),
+                      })
+                    }
+                  >
+                    ↓
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const options = field.options.filter(
+                        (_, i) => i !== index,
+                      )
+                      const defaultValue =
+                        field.defaultValue === option.value
+                          ? undefined
+                          : field.defaultValue
+                      onChange({ ...field, options, defaultValue })
+                    }}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  ...field,
+                  options: [...field.options, { value: "", label: "" }],
+                })
+              }
+            >
+              Add option
+            </button>
+          </div>
+
+          <label className="field-inspector__field">
+            Default selection
+            <select
+              value={field.defaultValue ?? ""}
+              onChange={(event) =>
+                onChange({
+                  ...field,
+                  defaultValue: event.target.value || undefined,
+                })
+              }
+            >
+              <option value="">None</option>
+              {field.options.map((option, index) => (
+                <option key={index} value={option.value}>
+                  {option.label || option.value}
+                </option>
+              ))}
+            </select>
+          </label>
+        </>
+      )}
     </aside>
   )
+}
+
+function replaceOption(
+  options: DropdownOption[],
+  index: number,
+  next: DropdownOption,
+): DropdownOption[] {
+  return options.map((option, i) => (i === index ? next : option))
+}
+
+function moveOption(
+  options: DropdownOption[],
+  from: number,
+  to: number,
+): DropdownOption[] {
+  const next = [...options]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return next
 }

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -32,7 +32,7 @@ function createField(type: FieldType): Field {
     case "textarea":
       return { id, type, label }
     case "dropdown":
-      return { id, type, label }
+      return { id, type, label, required: false, options: [] }
   }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -23,7 +23,13 @@ export {
   TextFieldSchema,
   TextAreaFieldSchema,
   DropdownFieldSchema,
+  DropdownOptionSchema,
   FIELD_TYPES,
   FIELD_TYPE_LABELS,
 } from "./schemas/field.js"
-export type { Field, FieldType, TextField } from "./schemas/field.js"
+export type {
+  Field,
+  FieldType,
+  TextField,
+  DropdownOption,
+} from "./schemas/field.js"

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -39,10 +39,24 @@ export const TextAreaFieldSchema = z.object({
   label: z.string(),
 })
 
+// US-3.3: a dropdown field with an admin-defined list of options.
+export const DropdownOptionSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+})
+
+export type DropdownOption = z.infer<typeof DropdownOptionSchema>
+
 export const DropdownFieldSchema = z.object({
   id: z.string(),
   type: z.literal("dropdown"),
   label: z.string(),
+  required: z.boolean().default(false),
+  options: z.array(DropdownOptionSchema).default([]),
+  // Must match one of `options`' values, enforced where options are edited
+  // rather than in this shape (a value can be added and made default in
+  // the same edit).
+  defaultValue: z.string().optional(),
 })
 
 export const FieldSchema = z.discriminatedUnion("type", [


### PR DESCRIPTION
## Summary
- `DropdownFieldSchema` gains `options: { value, label }[]`, `required`, and `defaultValue`.
- The field inspector's dropdown section lets an admin:
  - Add, edit (label and value independently), reorder (↑/↓), and delete options.
  - Toggle the field's own required flag.
  - Pick a default selection from the current options (or "None").
- Deleting an option that was set as the default clears the default rather than leaving it pointing at a value that no longer exists.

Closes #12.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client):
  - Dragged a Dropdown field onto the canvas; inspector showed Required, an empty Options list, and Default selection.
  - Added two options (Red/red, Blue/blue), verified via `GET .../draft` they persisted with the right value/label pairs.
  - Removed an extra option — persisted correctly, list back to 2.
  - Set default selection to "blue" — persisted as `"defaultValue":"blue"`.
  - Clicked ↑ on the second option (Red) — persisted in swapped order (Blue, Red), confirming reorder works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)