### PR TITLE
US-3.4: Additional field types

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -105,3 +105,23 @@ body {
 .field-inspector__field--checkbox input {
   width: auto;
 }
+
+.field-inspector__options {
+  list-style: none;
+  margin: 0.25rem 0;
+  padding: 0;
+}
+
+.field-inspector__option {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.field-inspector__option input {
+  min-width: 0;
+  flex: 1;
+  padding: 0.25rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}

--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -1,13 +1,13 @@
-import type { Field } from "shared"
+import type { Field, FieldOption, RadioField } from "shared"
 
 interface FieldInspectorProps {
   field: Field | null
   onChange: (field: Field) => void
 }
 
-// Configuration panel for the field selected on the canvas. Only "text"
-// has type-specific options so far (US-3.1); other types grow their own
-// as their field-types epic issues land.
+// Configuration panel for the field selected on the canvas. Each type's
+// own options (US-3.1, US-3.4) grow independently here as their
+// field-types epic issues land.
 export function FieldInspector({ field, onChange }: FieldInspectorProps) {
   if (!field) {
     return (
@@ -49,16 +49,7 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
               }
             />
           </label>
-          <label className="field-inspector__field field-inspector__field--checkbox">
-            <input
-              type="checkbox"
-              checked={field.required}
-              onChange={(event) =>
-                onChange({ ...field, required: event.target.checked })
-              }
-            />
-            Required
-          </label>
+          <RequiredCheckbox field={field} onChange={onChange} />
           <label className="field-inspector__field">
             Max length
             <input
@@ -76,6 +67,235 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
           </label>
         </>
       )}
+
+      {field.type === "checkbox" && (
+        <>
+          <RequiredCheckbox field={field} onChange={onChange} />
+          <label className="field-inspector__field field-inspector__field--checkbox">
+            <input
+              type="checkbox"
+              checked={field.defaultChecked}
+              onChange={(event) =>
+                onChange({ ...field, defaultChecked: event.target.checked })
+              }
+            />
+            Checked by default
+          </label>
+        </>
+      )}
+
+      {field.type === "radio" && (
+        <>
+          <RequiredCheckbox field={field} onChange={onChange} />
+          <OptionsEditor field={field} onChange={onChange} />
+        </>
+      )}
+
+      {field.type === "date" && (
+        <>
+          <RequiredCheckbox field={field} onChange={onChange} />
+          <label className="field-inspector__field">
+            Earliest date
+            <input
+              type="date"
+              value={field.min ?? ""}
+              onChange={(event) =>
+                onChange({ ...field, min: event.target.value || undefined })
+              }
+            />
+          </label>
+          <label className="field-inspector__field">
+            Latest date
+            <input
+              type="date"
+              value={field.max ?? ""}
+              onChange={(event) =>
+                onChange({ ...field, max: event.target.value || undefined })
+              }
+            />
+          </label>
+        </>
+      )}
+
+      {field.type === "number" && (
+        <>
+          <RequiredCheckbox field={field} onChange={onChange} />
+          <label className="field-inspector__field">
+            Minimum
+            <input
+              type="number"
+              value={field.min ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  min: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+          <label className="field-inspector__field">
+            Maximum
+            <input
+              type="number"
+              value={field.max ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  max: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+          <label className="field-inspector__field">
+            Step
+            <input
+              type="number"
+              min={0}
+              value={field.step ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  step: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+        </>
+      )}
     </aside>
+  )
+}
+
+// Any field type with a `required` flag can render this the same way.
+function RequiredCheckbox({
+  field,
+  onChange,
+}: {
+  field: Extract<Field, { required: boolean }>
+  onChange: (field: Field) => void
+}) {
+  return (
+    <label className="field-inspector__field field-inspector__field--checkbox">
+      <input
+        type="checkbox"
+        checked={field.required}
+        onChange={(event) =>
+          onChange({ ...field, required: event.target.checked })
+        }
+      />
+      Required
+    </label>
+  )
+}
+
+// Add/edit/reorder/delete the option list for a "radio" field.
+function OptionsEditor({
+  field,
+  onChange,
+}: {
+  field: RadioField
+  onChange: (field: Field) => void
+}) {
+  function replaceOption(index: number, next: FieldOption) {
+    onChange({
+      ...field,
+      options: field.options.map((option, i) => (i === index ? next : option)),
+    })
+  }
+
+  function moveOption(from: number, to: number) {
+    const next = [...field.options]
+    const [moved] = next.splice(from, 1)
+    next.splice(to, 0, moved)
+    onChange({ ...field, options: next })
+  }
+
+  function removeOption(index: number) {
+    const removed = field.options[index]
+    const options = field.options.filter((_, i) => i !== index)
+    const defaultValue =
+      field.defaultValue === removed.value ? undefined : field.defaultValue
+    onChange({ ...field, options, defaultValue })
+  }
+
+  return (
+    <>
+      <div className="field-inspector__field">
+        Options
+        <ul className="field-inspector__options">
+          {field.options.map((option, index) => (
+            <li key={index} className="field-inspector__option">
+              <input
+                type="text"
+                placeholder="Label"
+                value={option.label}
+                onChange={(event) =>
+                  replaceOption(index, { ...option, label: event.target.value })
+                }
+              />
+              <input
+                type="text"
+                placeholder="Value"
+                value={option.value}
+                onChange={(event) =>
+                  replaceOption(index, { ...option, value: event.target.value })
+                }
+              />
+              <button
+                type="button"
+                disabled={index === 0}
+                onClick={() => moveOption(index, index - 1)}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                disabled={index === field.options.length - 1}
+                onClick={() => moveOption(index, index + 1)}
+              >
+                ↓
+              </button>
+              <button type="button" onClick={() => removeOption(index)}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+        <button
+          type="button"
+          onClick={() =>
+            onChange({
+              ...field,
+              options: [...field.options, { value: "", label: "" }],
+            })
+          }
+        >
+          Add option
+        </button>
+      </div>
+
+      <label className="field-inspector__field">
+        Default selection
+        <select
+          value={field.defaultValue ?? ""}
+          onChange={(event) =>
+            onChange({
+              ...field,
+              defaultValue: event.target.value || undefined,
+            })
+          }
+        >
+          <option value="">None</option>
+          {field.options.map((option, index) => (
+            <option key={index} value={option.value}>
+              {option.label || option.value}
+            </option>
+          ))}
+        </select>
+      </label>
+    </>
   )
 }

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -33,6 +33,14 @@ function createField(type: FieldType): Field {
       return { id, type, label }
     case "dropdown":
       return { id, type, label }
+    case "checkbox":
+      return { id, type, label, required: false, defaultChecked: false }
+    case "radio":
+      return { id, type, label, required: false, options: [] }
+    case "date":
+      return { id, type, label, required: false }
+    case "number":
+      return { id, type, label, required: false }
   }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -20,10 +20,24 @@ export type {
 export {
   FieldSchema,
   FieldTypeSchema,
+  FieldOptionSchema,
   TextFieldSchema,
   TextAreaFieldSchema,
   DropdownFieldSchema,
+  CheckboxFieldSchema,
+  RadioFieldSchema,
+  DateFieldSchema,
+  NumberFieldSchema,
   FIELD_TYPES,
   FIELD_TYPE_LABELS,
 } from "./schemas/field.js"
-export type { Field, FieldType, TextField } from "./schemas/field.js"
+export type {
+  Field,
+  FieldType,
+  FieldOption,
+  TextField,
+  CheckboxField,
+  RadioField,
+  DateField,
+  NumberField,
+} from "./schemas/field.js"

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -3,7 +3,15 @@ import { z } from "zod"
 // Per-type configuration lands as each field-types epic issue is built.
 // This is a discriminated union (per US-3.4's "extensible type registry")
 // so a new type/config can be added without touching the others.
-export const FieldTypeSchema = z.enum(["text", "textarea", "dropdown"])
+export const FieldTypeSchema = z.enum([
+  "text",
+  "textarea",
+  "dropdown",
+  "checkbox",
+  "radio",
+  "date",
+  "number",
+])
 
 export type FieldType = z.infer<typeof FieldTypeSchema>
 
@@ -11,12 +19,20 @@ export const FIELD_TYPES: readonly FieldType[] = [
   "text",
   "textarea",
   "dropdown",
+  "checkbox",
+  "radio",
+  "date",
+  "number",
 ]
 
 export const FIELD_TYPE_LABELS: Record<FieldType, string> = {
   text: "Text",
   textarea: "Text area",
   dropdown: "Dropdown",
+  checkbox: "Checkbox",
+  radio: "Radio group",
+  date: "Date",
+  number: "Number",
 }
 
 // US-3.1: a single-line text field, configurable beyond just its label.
@@ -31,24 +47,87 @@ export const TextFieldSchema = z.object({
 
 export type TextField = z.infer<typeof TextFieldSchema>
 
-// Not yet configurable beyond a label — their own field-types epic issues
-// (US-3.2, US-3.3) extend these.
+// Not yet configurable beyond a label — its own field-types epic issue
+// (US-3.2) extends this.
 export const TextAreaFieldSchema = z.object({
   id: z.string(),
   type: z.literal("textarea"),
   label: z.string(),
 })
 
+// A labeled list of selectable values, shared by "dropdown" and "radio".
+export const FieldOptionSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+})
+
+export type FieldOption = z.infer<typeof FieldOptionSchema>
+
+// Not yet configurable beyond a label — its own field-types epic issue
+// (US-3.3) extends this.
 export const DropdownFieldSchema = z.object({
   id: z.string(),
   type: z.literal("dropdown"),
   label: z.string(),
 })
 
+// US-3.4: a single checkbox, e.g. "I agree to the terms".
+export const CheckboxFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("checkbox"),
+  label: z.string(),
+  required: z.boolean().default(false),
+  defaultChecked: z.boolean().default(false),
+})
+
+export type CheckboxField = z.infer<typeof CheckboxFieldSchema>
+
+// US-3.4: a mutually-exclusive group of options, all visible at once
+// (unlike "dropdown", which hides them behind a closed control).
+export const RadioFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("radio"),
+  label: z.string(),
+  required: z.boolean().default(false),
+  options: z.array(FieldOptionSchema).default([]),
+  defaultValue: z.string().optional(),
+})
+
+export type RadioField = z.infer<typeof RadioFieldSchema>
+
+// US-3.4: a calendar date, optionally bounded to a range.
+export const DateFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("date"),
+  label: z.string(),
+  required: z.boolean().default(false),
+  min: z.string().optional(),
+  max: z.string().optional(),
+})
+
+export type DateField = z.infer<typeof DateFieldSchema>
+
+// US-3.4: a numeric value, optionally bounded and steppable.
+export const NumberFieldSchema = z.object({
+  id: z.string(),
+  type: z.literal("number"),
+  label: z.string(),
+  required: z.boolean().default(false),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  step: z.number().positive().optional(),
+})
+
+export type NumberField = z.infer<typeof NumberFieldSchema>
+
 export const FieldSchema = z.discriminatedUnion("type", [
   TextFieldSchema,
   TextAreaFieldSchema,
   DropdownFieldSchema,
+  CheckboxFieldSchema,
+  RadioFieldSchema,
+  DateFieldSchema,
+  NumberFieldSchema,
 ])
 
 export type Field = z.infer<typeof FieldSchema>


### PR DESCRIPTION
## Summary
Adds four more field types beyond text/dropdown, each as its own variant in the `Field` discriminated union with the configuration relevant to it:
- **Checkbox** — required, checked by default.
- **Radio group** — required, an admin-editable options list (add/edit/reorder/delete, same value+label shape as dropdown), and a default selection.
- **Date** — required, earliest/latest date bounds.
- **Number** — required, min/max/step.

Each type slots into the existing palette, canvas, and inspector purely by adding a new schema variant — no changes to the other types' shapes, satisfying the "extensible type registry" goal. `FieldOptionSchema` is factored out so "dropdown" and "radio" can share the same option shape once both exist together.

Closes #13.

## Test plan
- [x] `npm run typecheck` passes for `shared`, `server`, and `client`.
- [x] Ran the full stack (Postgres + server + Vite client):
  - Palette lists all 7 types now (Text, Text area, Dropdown, Checkbox, Radio group, Date, Number).
  - Dragged one of each new type onto the canvas; inspector showed the right controls per type (Checkbox: Required + Checked by default; Radio group: Required + options editor + default selection; Date: Required + Earliest/Latest date; Number: Required + Minimum/Maximum/Step).
  - Configured each (added a radio option "Yes"/"yes", set date min to 2026-01-01, set number min/max/step to 0/10/1) and verified via `GET .../draft` that every field's config persisted correctly and independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)