### PR TITLE
US-2.3/2.4/2.5: Edit a field's label, delete a field, preview the form

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -154,3 +154,17 @@ body {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
+.field-inspector__error {
+  color: #c0392b;
+  font-size: 0.8125rem;
+}
+
+.field-inspector__delete {
+  color: #c0392b;
+  border-color: #c0392b;
+}
+
+.form-preview__empty {
+  color: #888;
+}

--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from "react"
 import type { Field } from "shared"
 
 interface FieldInspectorProps {
   field: Field | null
   onChange: (field: Field) => void
+  onDelete: (fieldId: string) => void
+  isPublished: (fieldId: string) => boolean
 }
 
 // Configuration panel for the field selected on the canvas. Label and
@@ -10,7 +13,22 @@ interface FieldInspectorProps {
 // (like "text"'s placeholder/maxLength, US-3.1; "dropdown"/"radio"'s
 // options list, US-3.3/US-3.4; and "checkbox"/"date"/"number"'s own
 // settings, US-3.4) grow as their own field-types epic issues land.
-export function FieldInspector({ field, onChange }: FieldInspectorProps) {
+export function FieldInspector({
+  field,
+  onChange,
+  onDelete,
+  isPublished,
+}: FieldInspectorProps) {
+  // Tracks the label input's own text so an admin can pass through an
+  // empty string while typing (e.g. selecting-all to retype) without that
+  // getting persisted as an invalid label (US-2.3). Only a non-empty,
+  // trimmed value is ever forwarded to onChange.
+  const [labelDraft, setLabelDraft] = useState(field?.label ?? "")
+
+  useEffect(() => {
+    setLabelDraft(field?.label ?? "")
+  }, [field?.id])
+
   if (!field) {
     return (
       <aside className="field-inspector">
@@ -22,6 +40,21 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
     )
   }
 
+  const labelIsEmpty = labelDraft.trim().length === 0
+  const fieldId = field.id
+
+  function handleDelete() {
+    if (
+      isPublished(fieldId) &&
+      !window.confirm(
+        "This field is part of a previously published version of this form. Deleting it won't affect submissions already collected, but it will be gone from every future version. Delete anyway?",
+      )
+    ) {
+      return
+    }
+    onDelete(fieldId)
+  }
+
   return (
     <aside className="field-inspector">
       <h2>Field settings</h2>
@@ -29,11 +62,20 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
         Label
         <input
           type="text"
-          value={field.label}
-          onChange={(event) =>
-            onChange({ ...field, label: event.target.value })
-          }
+          value={labelDraft}
+          onChange={(event) => {
+            const value = event.target.value
+            setLabelDraft(value)
+            if (value.trim().length > 0) {
+              onChange({ ...field, label: value })
+            }
+          }}
         />
+        {labelIsEmpty && (
+          <span className="field-inspector__error" role="alert">
+            Label can't be empty.
+          </span>
+        )}
       </label>
       <label className="field-inspector__field field-inspector__field--checkbox">
         <input
@@ -168,6 +210,14 @@ export function FieldInspector({ field, onChange }: FieldInspectorProps) {
           </label>
         </>
       )}
+
+      <button
+        type="button"
+        className="field-inspector__delete"
+        onClick={handleDelete}
+      >
+        Delete field
+      </button>
     </aside>
   )
 }

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react"
 import { FIELD_TYPE_LABELS, type Field, type FieldType } from "shared"
-import { getDraft, saveDraft } from "./api.js"
+import { getDraft, getPublishedFieldIds, saveDraft } from "./api.js"
 import { FieldInspector } from "./FieldInspector.js"
 import { FieldPalette } from "./FieldPalette.js"
 import { FormCanvas } from "./FormCanvas.js"
+import { FormPreview } from "./FormPreview.js"
 
 interface FormBuilderProps {
   formId: string
@@ -46,8 +47,9 @@ function createField(type: FieldType): Field {
 
 // Loads the form's current draft, then lets an admin drag field types from
 // the palette onto the canvas to build it visually (US-2.1), reorder them
-// (US-2.2), and configure the selected field — including marking it
-// required (US-3.1, US-3.5).
+// (US-2.2), configure the selected field — including marking it required
+// (US-3.1, US-3.5), edit its label (US-2.3), delete it (US-2.4), and
+// preview the form (US-2.5).
 export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
   const [fields, setFields] = useState<Field[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -55,6 +57,10 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     "loading",
   )
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [publishedFieldIds, setPublishedFieldIds] = useState<Set<string>>(
+    new Set(),
+  )
+  const [mode, setMode] = useState<"edit" | "preview">("edit")
 
   useEffect(() => {
     let cancelled = false
@@ -67,6 +73,13 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
       })
       .catch(() => {
         if (!cancelled) setStatus("error")
+      })
+    getPublishedFieldIds(formId)
+      .then((ids) => {
+        if (!cancelled) setPublishedFieldIds(new Set(ids))
+      })
+      .catch(() => {
+        // Best-effort: the delete-confirmation prompt just won't fire.
       })
     return () => {
       cancelled = true
@@ -97,6 +110,11 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     persist(fields.map((field) => (field.id === next.id ? next : field)))
   }
 
+  function handleDelete(fieldId: string) {
+    persist(fields.filter((field) => field.id !== fieldId))
+    setSelectedId((current) => (current === fieldId ? null : current))
+  }
+
   const selectedField = fields.find((field) => field.id === selectedId) ?? null
 
   return (
@@ -106,13 +124,25 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
           ← Back
         </button>
         <h1>{formName}</h1>
+        {status === "ready" && (
+          <button
+            type="button"
+            onClick={() => setMode(mode === "edit" ? "preview" : "edit")}
+          >
+            {mode === "edit" ? "Preview" : "Back to editing"}
+          </button>
+        )}
       </header>
 
       {status === "loading" && <p>Loading…</p>}
       {status === "error" && <p role="alert">Couldn't load this form.</p>}
       {saveError && <p role="alert">{saveError}</p>}
 
-      {status === "ready" && (
+      {status === "ready" && mode === "preview" && (
+        <FormPreview fields={fields} />
+      )}
+
+      {status === "ready" && mode === "edit" && (
         <div className="form-builder__workspace">
           <FieldPalette />
           <FormCanvas
@@ -122,7 +152,12 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
             onReorder={handleReorder}
             onSelect={setSelectedId}
           />
-          <FieldInspector field={selectedField} onChange={handleFieldChange} />
+          <FieldInspector
+            field={selectedField}
+            onChange={handleFieldChange}
+            onDelete={handleDelete}
+            isPublished={(fieldId) => publishedFieldIds.has(fieldId)}
+          />
         </div>
       )}
     </main>

--- a/client/src/FormPreview.tsx
+++ b/client/src/FormPreview.tsx
@@ -1,0 +1,40 @@
+import { useMemo, useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import type { Field } from "shared"
+import { toJsonSchema } from "./schema/toJsonSchema.js"
+
+interface FormPreviewProps {
+  fields: Field[]
+}
+
+// Renders the draft schema with the same JSON Forms renderer end users
+// will see (ADR-0003), so an admin can check layout and behaviour before
+// publishing (US-2.5). Input here is scratch state only — nothing is
+// persisted from the preview.
+export function FormPreview({ fields }: FormPreviewProps) {
+  const { schema, uiSchema } = useMemo(
+    () => toJsonSchema({ fields }),
+    [fields],
+  )
+  const [data, setData] = useState<Record<string, unknown>>({})
+
+  return (
+    <div className="form-preview">
+      {fields.length === 0 ? (
+        <p className="form-preview__empty">
+          Add a field to the canvas to preview the form.
+        </p>
+      ) : (
+        <JsonForms
+          schema={schema}
+          uischema={uiSchema}
+          data={data}
+          renderers={vanillaRenderers}
+          cells={vanillaCells}
+          onChange={({ data }) => setData(data)}
+        />
+      )}
+    </div>
+  )
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -75,3 +75,9 @@ export async function submitForm(
   }
   return json<Submission>(res)
 }
+
+export function getPublishedFieldIds(formId: string): Promise<string[]> {
+  return fetch(`/api/forms/${formId}/published-field-ids`).then((res) =>
+    json<string[]>(res),
+  )
+}

--- a/client/src/schema/toJsonSchema.ts
+++ b/client/src/schema/toJsonSchema.ts
@@ -1,0 +1,93 @@
+import type { JsonSchema7 } from "@jsonforms/core"
+import type { Field, FormSchema } from "shared"
+
+// Converts the builder's draft FormSchema into the JSON Schema + UI Schema
+// pair JSON Forms renders from (ADR-0003). This is a stand-in for the
+// generic Zod-to-JSON-Schema conversion US-0.3 will wire up, covering every
+// field type the canvas currently supports (US-3.1 through US-3.4); it's
+// meant to be replaced by that conversion once it lands.
+export function toJsonSchema(schema: FormSchema) {
+  const properties: Record<string, JsonSchema7> = {}
+  const required: string[] = []
+  const elements = schema.fields.map((field) => {
+    properties[field.id] = toProperty(field)
+    if (field.required) required.push(field.id)
+    return toUiSchemaElement(field)
+  })
+
+  return {
+    schema: {
+      type: "object" as const,
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+    },
+    uiSchema: {
+      type: "VerticalLayout" as const,
+      elements,
+    },
+  }
+}
+
+// A labeled list of options (dropdown/radio) becomes a `oneOf` of
+// const/title pairs rather than a plain `enum`, so the option's label
+// (not its raw value) is what renders.
+function toOneOf(options: { value: string; label: string }[]) {
+  return options.map((option) => ({
+    const: option.value,
+    title: option.label,
+  }))
+}
+
+function toProperty(field: Field): JsonSchema7 {
+  switch (field.type) {
+    case "text":
+      return {
+        type: "string",
+        title: field.label,
+        ...(field.maxLength ? { maxLength: field.maxLength } : {}),
+      }
+    case "textarea":
+      return { type: "string", title: field.label }
+    case "dropdown":
+    case "radio":
+      return {
+        type: "string",
+        title: field.label,
+        ...(field.options.length > 0
+          ? { oneOf: toOneOf(field.options) }
+          : {}),
+        ...(field.defaultValue ? { default: field.defaultValue } : {}),
+      }
+    case "checkbox":
+      return {
+        type: "boolean",
+        title: field.label,
+        default: field.defaultChecked,
+      }
+    case "date":
+      return {
+        type: "string",
+        title: field.label,
+        format: "date",
+        ...(field.min ? { formatMinimum: field.min } : {}),
+        ...(field.max ? { formatMaximum: field.max } : {}),
+      }
+    case "number":
+      return {
+        type: "number",
+        title: field.label,
+        ...(field.min !== undefined ? { minimum: field.min } : {}),
+        ...(field.max !== undefined ? { maximum: field.max } : {}),
+        ...(field.step ? { multipleOf: field.step } : {}),
+      }
+  }
+}
+
+function toUiSchemaElement(field: Field) {
+  return {
+    type: "Control" as const,
+    scope: `#/properties/${field.id}`,
+    ...(field.type === "textarea" ? { options: { multi: true } } : {}),
+    ...(field.type === "radio" ? { options: { format: "radio" } } : {}),
+  }
+}

--- a/server/src/modules/form-builder/routes.ts
+++ b/server/src/modules/form-builder/routes.ts
@@ -8,6 +8,7 @@ import {
   FormSummarySchema,
   FormVersionHistorySchema,
   FormVersionSchema,
+  PublishedFieldIdsSchema,
   PublishFormVersionSchema,
   type FormSchema,
 } from "shared"
@@ -204,6 +205,32 @@ export function formBuilderPlugin(
             publishedAt: version.publishedAt?.toISOString() ?? null,
             publishedBy: version.publishedBy,
           }))
+        } catch (error) {
+          if (error instanceof FormNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/published-field-ids",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: {
+            200: PublishedFieldIdsSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const ids = await versionsService.listPublishedFieldIds(
+            request.params.formId,
+          )
+          return reply.code(200).send(ids)
         } catch (error) {
           if (error instanceof FormNotFoundError) {
             return reply.code(404).send({ message: error.message })

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -1,3 +1,4 @@
+import type { FormSchema } from "shared"
 import type { FormVersionsRepository } from "../repositories/form-versions.js"
 
 export class FormVersionsService {
@@ -21,5 +22,21 @@ export class FormVersionsService {
 
   getActiveVersion(formId: string) {
     return this.repo.getActiveVersion(formId)
+  }
+
+  // The field ids that appear in any version other than the current draft
+  // (US-2.4): deleting one of these from the draft has downstream impact on
+  // submissions already collected against a published version.
+  async listPublishedFieldIds(formId: string): Promise<string[]> {
+    const versions = await this.repo.listVersions(formId)
+    const ids = new Set<string>()
+    for (const version of versions) {
+      if (version.status === "draft") continue
+      // The jsonb column is untyped at the DB layer; the app is the only
+      // writer and always writes the FormSchema shape.
+      const schema = version.schema as FormSchema
+      for (const field of schema.fields) ids.add(field.id)
+    }
+    return [...ids]
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -10,12 +10,14 @@ export {
   PublishFormVersionSchema,
   FormVersionSummarySchema,
   FormVersionHistorySchema,
+  PublishedFieldIdsSchema,
 } from "./schemas/form-version.js"
 export type {
   FormVersion,
   FormSchema,
   PublishFormVersion,
   FormVersionSummary,
+  PublishedFieldIds,
 } from "./schemas/form-version.js"
 export {
   FieldSchema,

--- a/shared/src/schemas/form-version.ts
+++ b/shared/src/schemas/form-version.ts
@@ -47,3 +47,12 @@ export const FormVersionSummarySchema = z.object({
 export type FormVersionSummary = z.infer<typeof FormVersionSummarySchema>
 
 export const FormVersionHistorySchema = z.array(FormVersionSummarySchema)
+
+// The set of field ids that appear in any version of the form that was
+// ever published (i.e. every version except the current draft). Deleting
+// one of these from the draft (US-2.4) has downstream impact on whatever
+// already-collected submissions reference that version, so the builder UI
+// confirms before removing it.
+export const PublishedFieldIdsSchema = z.array(z.string())
+
+export type PublishedFieldIds = z.infer<typeof PublishedFieldIdsSchema>


### PR DESCRIPTION
## Summary
- **#7** Label edits in the field inspector are staged locally so an empty label never reaches the draft; an inline validation message shows instead.
- **#8** Adds a "Delete field" button. Deleting a field that appears in any previously published version (tracked via a new `GET /api/forms/:formId/published-field-ids` endpoint) prompts for confirmation first.
- **#9** Adds a Preview toggle that renders the draft schema with the same JSON Forms renderer end users will see, via a converter (`client/src/schema/toJsonSchema.ts`) that stands in for US-0.3's eventual Zod-to-JSON-Schema conversion. Covers all 7 current field types: text, textarea, dropdown, checkbox, radio, date, and number.

Rebased twice onto a moving base branch (after #37/#38, then again after #39/#40) and reconciled with the "required field" (#14) and "dropdown/additional field types" (#12, #13) work landing concurrently — the delete button, label validation, and preview all coexist with required-field checkboxes/badges and the full field-type set.

Closes #7, Closes #8, Closes #9

## Test plan
- [x] `npm run typecheck`
- [x] Ran the full stack (Postgres via docker compose, server, client dev server) and verified in the browser:
  - Clearing a field's label shows the validation message and doesn't persist the empty value; retyping a valid label clears it
  - Deleting a field not in any published version deletes immediately with no prompt
  - Deleting a field that is in a published version prompts for confirmation; cancelling keeps it, confirming removes it
  - Preview renders all 7 field types from the draft schema with live data binding: required markers/validation on text and checkbox, dropdown and radio option labels rendering correctly (verified via each `<option>`'s `label` attribute), native date and number inputs