### PR TITLE
US-4.1: Render a published form for data entry

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -140,19 +140,8 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.form-fill__field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 1rem;
+.form-fill {
   max-width: 24rem;
-}
-
-.form-fill__field input,
-.form-fill__field textarea {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
 }
 
 .field-inspector__error {

--- a/client/src/FormFill.tsx
+++ b/client/src/FormFill.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useState } from "react"
-import type { Field, FormVersion } from "shared"
+import { useEffect, useMemo, useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import type { FormVersion } from "shared"
 import { getActiveVersion, SubmissionRejectedError, submitForm } from "./api.js"
+import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface FormFillProps {
   formId: string
@@ -10,12 +13,19 @@ interface FormFillProps {
 
 type Status = "loading" | "ready" | "no-active" | "error" | "submitted"
 
-// The public-facing view a respondent fills out. Required fields are
-// enforced two ways: natively via HTML `required` here, and again by the
-// server at submission time in case that's ever bypassed (US-3.5).
+// The public-facing view a respondent fills out, rendered with the same
+// JSON Forms renderer used by the builder's preview (ADR-0003) so the UI
+// always matches the active schema version's field types and constraints
+// (US-4.1). Required fields and type constraints (enum, number range,
+// date bounds, ...) are validated client-side by JSON Forms/ajv against
+// the generated JSON Schema, and independently re-checked by the server
+// at submission time in case that's ever bypassed (US-3.5).
 export function FormFill({ formId, formName, onBack }: FormFillProps) {
   const [version, setVersion] = useState<FormVersion | null>(null)
   const [status, setStatus] = useState<Status>("loading")
+  const [data, setData] = useState<Record<string, unknown>>({})
+  const [errors, setErrors] = useState<unknown[]>([])
+  const [showValidation, setShowValidation] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -25,6 +35,7 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
       .then((active) => {
         if (cancelled) return
         setVersion(active)
+        setData({})
         setStatus(active ? "ready" : "no-active")
       })
       .catch(() => {
@@ -35,13 +46,17 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
     }
   }, [formId])
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
+  const { schema, uiSchema } = useMemo(
+    () => toJsonSchema(version?.schema ?? { fields: [] }),
+    [version],
+  )
+
+  async function handleSubmit() {
+    if (errors.length > 0) {
+      setShowValidation(true)
+      return
+    }
     setSubmitError(null)
-    const data: Record<string, unknown> = {}
-    new FormData(event.currentTarget).forEach((value, key) => {
-      data[key] = value
-    })
     try {
       await submitForm(formId, data)
       setStatus("submitted")
@@ -72,35 +87,26 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
       {submitError && <p role="alert">{submitError}</p>}
 
       {status === "ready" && version && (
-        <form onSubmit={handleSubmit}>
-          {version.schema.fields.map((field) => (
-            <FieldInput key={field.id} field={field} />
-          ))}
-          <button type="submit">Submit</button>
-        </form>
+        <>
+          <JsonForms
+            schema={schema}
+            uischema={uiSchema}
+            data={data}
+            renderers={vanillaRenderers}
+            cells={vanillaCells}
+            validationMode={
+              showValidation ? "ValidateAndShow" : "ValidateAndHide"
+            }
+            onChange={({ data, errors }) => {
+              setData(data)
+              setErrors(errors ?? [])
+            }}
+          />
+          <button type="button" onClick={handleSubmit}>
+            Submit
+          </button>
+        </>
       )}
     </main>
-  )
-}
-
-function FieldInput({ field }: { field: Field }) {
-  return (
-    <label className="form-fill__field">
-      {field.label}
-      {field.required && <span aria-hidden="true"> *</span>}
-      {field.type === "textarea" ? (
-        <textarea name={field.id} required={field.required} />
-      ) : field.type === "text" ? (
-        <input
-          type="text"
-          name={field.id}
-          required={field.required}
-          placeholder={field.placeholder}
-          maxLength={field.maxLength}
-        />
-      ) : (
-        <input type="text" name={field.id} required={field.required} />
-      )}
-    </label>
   )
 }

--- a/client/src/schema/toJsonSchema.ts
+++ b/client/src/schema/toJsonSchema.ts
@@ -1,11 +1,14 @@
 import type { JsonSchema7 } from "@jsonforms/core"
 import type { Field, FormSchema } from "shared"
 
-// Converts the builder's draft FormSchema into the JSON Schema + UI Schema
-// pair JSON Forms renders from (ADR-0003). This is a stand-in for the
-// generic Zod-to-JSON-Schema conversion US-0.3 will wire up, covering every
-// field type the canvas currently supports (US-3.1 through US-3.4); it's
-// meant to be replaced by that conversion once it lands.
+// Converts a FormSchema into the JSON Schema + UI Schema pair JSON Forms
+// renders from (ADR-0003) — used for both the builder's draft preview
+// (US-2.5) and the public fill-out view (US-4.1), so what an admin
+// previews is exactly what a respondent later fills out. This is a
+// stand-in for the generic Zod-to-JSON-Schema conversion US-0.3 will wire
+// up, covering every field type the canvas currently supports (US-3.1
+// through US-3.4); it's meant to be replaced by that conversion once it
+// lands.
 export function toJsonSchema(schema: FormSchema) {
   const properties: Record<string, JsonSchema7> = {}
   const required: string[] = []


### PR DESCRIPTION
## Summary
- Replaces `FormFill`'s hand-rolled `<form>` with the same JSON Forms renderer the builder's preview (US-2.5) uses, via the shared `toJsonSchema` converter — the fill-out UI now correctly handles all 7 field types (text, textarea, dropdown, checkbox, radio, date, number) instead of falling back to a generic text input for anything past text/textarea.
- Client-side validation now matches the full field configuration (required, string maxLength, number min/max, enum options) via JSON Forms/ajv against the generated schema.
- Validation errors stay hidden until the first submit attempt is blocked, so respondents aren't shown "required" errors before touching the form.

Closes #15

## Test plan
- [x] `npm run typecheck`
- [x] Ran the full stack (Postgres via docker compose, server, client dev server) and verified in the browser:
  - Published a form with all 7 field types and opened "Fill out"
  - All fields render with correct native controls (text, textarea, select, checkbox, radio, date, number) and no premature validation errors
  - Submitting empty is blocked client-side with per-field "required" messages and no network request sent
  - Submitting a number outside its configured range (0–120) is blocked client-side with "must be <= 120" and no network request sent
  - A fully valid submission succeeds (201 Created) with correctly-typed data