### PR TITLE
US-4.2: Save a submission

### DIFF
--- a/docs/adr/0004-submission-storage-shape.md
+++ b/docs/adr/0004-submission-storage-shape.md
@@ -1,0 +1,51 @@
+# ADR-0004: Submission storage — typed columns vs. JSONB
+
+## Status
+
+Accepted
+
+## Context
+
+US-4.2 asks for a submission record to store its own metadata (form ID,
+schema version ID, submitted data, timestamp, submitted-by) and for
+"reportable/structured fields" to live in typed columns while "free-form/
+variable fields" live in JSONB.
+
+form-builder's field set per form is entirely admin-defined at runtime
+(`shared`'s `FieldSchema` discriminated union, extensible per US-3.4) — a
+form can have any number of fields of any supported type, added, reordered,
+or removed at will. There is no fixed set of "the answer fields" known at
+table-design time, so a real per-field typed column (one SQL column per
+field) isn't possible without either a schema migration on every form edit
+or a wide sparse table shared across all forms — both of which defeat the
+whole point of a dynamic form builder.
+
+What *is* fixed and known at table-design time is the submission's own
+metadata: which form and version it targets, when it was submitted, and by
+whom. That's exactly the "reportable/structured" half — the fields a query
+would filter or group submissions by (`WHERE form_id = ...`,
+`GROUP BY form_version_id`, `ORDER BY submitted_at`) — and it doesn't
+change per form.
+
+## Decision
+
+Store submission metadata in typed columns (`form_id`, `form_version_id`,
+`submitted_by`, `submitted_at`, plus `id`/`status`/timestamps) and the
+actual admin-defined answer set in a single `data jsonb` column, keyed by
+field id.
+
+`form_id` is denormalized from `form_version_id` (rather than requiring a
+join through `form_versions` for every query) since it's the column a
+reporting view is most likely to filter or group by directly.
+
+## Consequences
+
+- Querying/reporting on submission metadata (by form, by version, by date,
+  by submitter) uses plain typed-column SQL; no JSONB operators needed.
+- Querying/reporting on individual answers (e.g. "how many people picked
+  'Red'") requires JSONB operators (`data->>'field-id'`) against the
+  relevant field's id, since the answer set has no fixed shape.
+- If a future need arises to report heavily on one specific field across
+  many forms (e.g. a universal "email" field), that field would need its
+  own typed column and a deliberate decision to special-case it — not
+  something this ADR covers.

--- a/server/src/db/migrations/0004_smiling_living_tribunal.sql
+++ b/server/src/db/migrations/0004_smiling_living_tribunal.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "submissions" ADD COLUMN "form_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "submissions" ADD COLUMN "submitted_by" text;--> statement-breakpoint
+ALTER TABLE "submissions" ADD CONSTRAINT "submissions_form_id_forms_id_fk" FOREIGN KEY ("form_id") REFERENCES "public"."forms"("id") ON DELETE restrict ON UPDATE no action;

--- a/server/src/db/migrations/meta/0004_snapshot.json
+++ b/server/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,286 @@
+{
+  "id": "fab279a4-10cb-42dc-b24b-da4e9c4c3e98",
+  "prevId": "66ce847a-55af-467a-8b83-2b053aef0445",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_form_id_forms_id_fk": {
+          "name": "submissions_form_id_forms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787905278554,
       "tag": "0003_stale_major_mapleleaf",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1788144339885,
+      "tag": "0004_smiling_living_tribunal",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -76,9 +76,16 @@ export const formVersions = pgTable(
 
 // A submission always targets one specific version, so editing the form
 // later can never change what an existing submission is validated or
-// rendered against.
+// rendered against. `formId` is denormalized from `formVersionId` (rather
+// than requiring a join through form_versions) so reporting queries can
+// filter/group submissions by form directly (US-4.2). The submission's own
+// metadata lives in typed columns; the admin-defined, per-form answer set
+// itself has no fixed shape, so it lives in `data` (US-4.2).
 export const submissions = pgTable("submissions", {
   id: uuid("id").primaryKey().defaultRandom(),
+  formId: uuid("form_id")
+    .notNull()
+    .references(() => forms.id, { onDelete: "restrict" }),
   formVersionId: uuid("form_version_id")
     .notNull()
     .references(() => formVersions.id, { onDelete: "restrict" }),
@@ -86,6 +93,10 @@ export const submissions = pgTable("submissions", {
   status: text("status", { enum: ["draft", "submitted"] })
     .notNull()
     .default("draft"),
+  // Freeform identifier of who submitted this, mirroring `publishedBy`
+  // above -- there's no auth/user system yet, so this is whatever the
+  // caller supplies rather than a foreign key to a users table.
+  submittedBy: text("submitted_by"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -5,18 +5,27 @@ import type { SubmissionRow, SubmissionsRepository } from "./submissions.js"
 export class DrizzleSubmissionsRepository implements SubmissionsRepository {
   constructor(private readonly db: Db) {}
 
-  async create(formVersionId: string, data: unknown): Promise<SubmissionRow> {
+  async create(
+    formId: string,
+    formVersionId: string,
+    data: unknown,
+    submittedBy?: string | null,
+  ): Promise<SubmissionRow> {
     const [row] = await this.db
       .insert(submissions)
       .values({
+        formId,
         formVersionId,
         data,
+        submittedBy: submittedBy ?? null,
         status: "submitted",
         submittedAt: new Date(),
       })
       .returning({
         id: submissions.id,
+        formId: submissions.formId,
         formVersionId: submissions.formVersionId,
+        submittedBy: submissions.submittedBy,
         submittedAt: submissions.submittedAt,
       })
     // submittedAt is nullable at the column level (a submission can be

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -1,11 +1,18 @@
 export interface SubmissionRow {
   id: string
+  formId: string
   formVersionId: string
+  submittedBy: string | null
   submittedAt: Date
 }
 
 export interface SubmissionsRepository {
   // Records a completed submission against a specific form version, so it
   // always points at the exact schema it was captured against (US-1.3).
-  create(formVersionId: string, data: unknown): Promise<SubmissionRow>
+  create(
+    formId: string,
+    formVersionId: string,
+    data: unknown,
+    submittedBy?: string | null,
+  ): Promise<SubmissionRow>
 }

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -41,6 +41,7 @@ export function submissionsPlugin(
           const submission = await service.submit(
             request.params.formId,
             request.body.data,
+            request.body.submittedBy,
           )
           return reply.code(201).send({
             ...submission,

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -29,7 +29,11 @@ export class SubmissionsService {
   // Validates the submission against the form's active version before
   // recording it, so a required field can never be silently skipped even
   // if a client bypasses its own validation (US-3.5).
-  async submit(formId: string, data: Record<string, unknown>) {
+  async submit(
+    formId: string,
+    data: Record<string, unknown>,
+    submittedBy?: string | null,
+  ) {
     const active = await this.formVersions.getActiveVersion(formId)
     if (!active) {
       throw new NoActiveVersionError(formId)
@@ -44,6 +48,6 @@ export class SubmissionsService {
       throw new MissingRequiredFieldsError(missingFieldIds)
     }
 
-    return this.repo.create(active.id, data)
+    return this.repo.create(formId, active.id, data, submittedBy)
   }
 }

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -5,13 +5,19 @@ import { z } from "zod"
 // epic.
 export const SubmitFormSchema = z.object({
   data: z.record(z.string(), z.unknown()),
+  // Freeform identifier of who's submitting, mirroring
+  // PublishFormVersionSchema's `publishedBy` -- there's no auth/user system
+  // yet, so this is whatever the caller supplies (US-4.2).
+  submittedBy: z.string().min(1).optional(),
 })
 
 export type SubmitForm = z.infer<typeof SubmitFormSchema>
 
 export const SubmissionSchema = z.object({
   id: z.string(),
+  formId: z.string(),
   formVersionId: z.string(),
+  submittedBy: z.string().nullable(),
   submittedAt: z.iso.datetime(),
 })
 


### PR DESCRIPTION
## Summary
- Adds `form_id` (denormalized from `form_version_id`) and `submitted_by` (freeform, mirroring `form_versions.published_by` -- no auth system yet) to the `submissions` table, threaded through the submit-form API end to end.
- Records the typed-columns-vs-JSONB storage decision in `docs/adr/0004-submission-storage-shape.md`: fixed submission metadata (form/version ids, timestamps, submitted-by) lives in typed columns; the admin-defined, per-form answer set (no fixed shape) stays in the existing `data` jsonb column.

Closes #16

## Test plan
- [x] `npm run typecheck`
- [x] Ran the migration against a fresh Postgres instance -- applies cleanly
- [x] Submitted via the API with and without `submittedBy`; confirmed via `psql` that `form_id`/`form_version_id`/`submitted_by` land in typed columns and the answers stay in `data` jsonb, with `submitted_by` correctly `null` when omitted
- [x] Confirmed required-field validation still rejects an incomplete submission (400)
- [x] Confirmed the client's existing fill-out flow (#15) still submits successfully end to end in the browser