### PR TITLE
US-4.3: Save a draft submission

### DIFF
--- a/client/src/FormFill.tsx
+++ b/client/src/FormFill.tsx
@@ -2,7 +2,13 @@ import { useEffect, useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
 import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
 import type { FormVersion } from "shared"
-import { getActiveVersion, SubmissionRejectedError, submitForm } from "./api.js"
+import {
+  getActiveVersion,
+  getDraftSubmission,
+  saveDraftSubmission,
+  submitForm,
+  SubmissionRejectedError,
+} from "./api.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface FormFillProps {
@@ -12,6 +18,39 @@ interface FormFillProps {
 }
 
 type Status = "loading" | "ready" | "no-active" | "error" | "submitted"
+
+// Remembers the in-progress draft's id per form (US-4.3), so returning to
+// the same form later resumes it instead of starting over. Reads/writes
+// are wrapped in try/catch since localStorage can be unavailable (private
+// browsing, blocked site data) -- when it is, saving a draft still works
+// for the current visit, it just won't be resumable after a reload.
+function draftStorageKey(formId: string) {
+  return `form-fill-draft:${formId}`
+}
+
+function readSavedDraftId(formId: string): string | null {
+  try {
+    return window.localStorage.getItem(draftStorageKey(formId))
+  } catch {
+    return null
+  }
+}
+
+function writeSavedDraftId(formId: string, submissionId: string) {
+  try {
+    window.localStorage.setItem(draftStorageKey(formId), submissionId)
+  } catch {
+    // Best-effort only.
+  }
+}
+
+function clearSavedDraftId(formId: string) {
+  try {
+    window.localStorage.removeItem(draftStorageKey(formId))
+  } catch {
+    // Best-effort only.
+  }
+}
 
 // The public-facing view a respondent fills out, rendered with the same
 // JSON Forms renderer used by the builder's preview (ADR-0003) so the UI
@@ -27,20 +66,44 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
   const [errors, setErrors] = useState<unknown[]>([])
   const [showValidation, setShowValidation] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submissionId, setSubmissionId] = useState<string | null>(null)
+  const [draftMessage, setDraftMessage] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setStatus("loading")
-    getActiveVersion(formId)
-      .then((active) => {
-        if (cancelled) return
-        setVersion(active)
+    setSubmissionId(null)
+    setDraftMessage(null)
+
+    async function load() {
+      const active = await getActiveVersion(formId)
+      if (cancelled) return
+      setVersion(active)
+      if (!active) {
+        setStatus("no-active")
+        return
+      }
+
+      const savedDraftId = readSavedDraftId(formId)
+      const draft = savedDraftId
+        ? await getDraftSubmission(formId, savedDraftId)
+        : null
+      if (cancelled) return
+
+      if (draft) {
+        setData(draft.data)
+        setSubmissionId(draft.id)
+      } else {
+        if (savedDraftId) clearSavedDraftId(formId)
         setData({})
-        setStatus(active ? "ready" : "no-active")
-      })
-      .catch(() => {
-        if (!cancelled) setStatus("error")
-      })
+      }
+      setStatus("ready")
+    }
+
+    load().catch(() => {
+      if (!cancelled) setStatus("error")
+    })
+
     return () => {
       cancelled = true
     }
@@ -51,6 +114,23 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
     [version],
   )
 
+  async function handleSaveDraft() {
+    setSubmitError(null)
+    try {
+      const draft = await saveDraftSubmission(
+        formId,
+        data,
+        submissionId ?? undefined,
+      )
+      setSubmissionId(draft.id)
+      writeSavedDraftId(formId, draft.id)
+      setDraftMessage("Saved — you can return later to finish this form.")
+    } catch {
+      setDraftMessage(null)
+      setSubmitError("Couldn't save this draft. Please try again.")
+    }
+  }
+
   async function handleSubmit() {
     if (errors.length > 0) {
       setShowValidation(true)
@@ -58,7 +138,8 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
     }
     setSubmitError(null)
     try {
-      await submitForm(formId, data)
+      await submitForm(formId, data, submissionId ?? undefined)
+      clearSavedDraftId(formId)
       setStatus("submitted")
     } catch (error) {
       if (error instanceof SubmissionRejectedError) {
@@ -85,6 +166,7 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
       )}
       {status === "submitted" && <p>Thanks — your response was recorded.</p>}
       {submitError && <p role="alert">{submitError}</p>}
+      {draftMessage && <p>{draftMessage}</p>}
 
       {status === "ready" && version && (
         <>
@@ -100,8 +182,12 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
             onChange={({ data, errors }) => {
               setData(data)
               setErrors(errors ?? [])
+              setDraftMessage(null)
             }}
           />
+          <button type="button" onClick={handleSaveDraft}>
+            Save for later
+          </button>
           <button type="button" onClick={handleSubmit}>
             Submit
           </button>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -63,17 +63,46 @@ export class SubmissionRejectedError extends Error {
 export async function submitForm(
   formId: string,
   data: Record<string, unknown>,
+  submissionId?: string,
 ): Promise<Submission> {
   const res = await fetch(`/api/forms/${formId}/submissions`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ data }),
+    body: JSON.stringify({ data, submissionId }),
   })
   if (res.status === 400) {
     const body = (await res.json()) as SubmissionValidationError
     throw new SubmissionRejectedError(body.missingFieldIds)
   }
   return json<Submission>(res)
+}
+
+// Saves an in-progress submission with no required-field validation, so a
+// respondent can return and finish it later (US-4.3). With no
+// `submissionId`, creates a new draft; with one, overwrites that draft's
+// data in place.
+export function saveDraftSubmission(
+  formId: string,
+  data: Record<string, unknown>,
+  submissionId?: string,
+): Promise<Submission> {
+  return fetch(`/api/forms/${formId}/submissions/draft`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ data, submissionId }),
+  }).then((res) => json<Submission>(res))
+}
+
+// Fetches a saved draft to resume filling it out. Resolves to null if it
+// no longer exists, belongs to a different form, or has already been
+// finalized (US-4.3).
+export function getDraftSubmission(
+  formId: string,
+  submissionId: string,
+): Promise<Submission | null> {
+  return fetch(`/api/forms/${formId}/submissions/draft/${submissionId}`).then(
+    (res) => json<Submission | null>(res),
+  )
 }
 
 export function getPublishedFieldIds(formId: string): Promise<string[]> {

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,6 +1,17 @@
+import { and, eq } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
 import { submissions } from "../../../db/schema.js"
 import type { SubmissionRow, SubmissionsRepository } from "./submissions.js"
+
+const SUBMISSION_COLUMNS = {
+  id: submissions.id,
+  formId: submissions.formId,
+  formVersionId: submissions.formVersionId,
+  status: submissions.status,
+  data: submissions.data,
+  submittedBy: submissions.submittedBy,
+  submittedAt: submissions.submittedAt,
+}
 
 export class DrizzleSubmissionsRepository implements SubmissionsRepository {
   constructor(private readonly db: Db) {}
@@ -21,15 +32,79 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
         status: "submitted",
         submittedAt: new Date(),
       })
-      .returning({
-        id: submissions.id,
-        formId: submissions.formId,
-        formVersionId: submissions.formVersionId,
-        submittedBy: submissions.submittedBy,
-        submittedAt: submissions.submittedAt,
+      .returning(SUBMISSION_COLUMNS)
+    return row
+  }
+
+  async saveDraft(
+    formId: string,
+    formVersionId: string,
+    data: unknown,
+    submissionId?: string,
+  ): Promise<SubmissionRow> {
+    if (submissionId) {
+      const [updated] = await this.db
+        .update(submissions)
+        .set({ data, formVersionId, updatedAt: new Date() })
+        .where(
+          and(
+            eq(submissions.id, submissionId),
+            eq(submissions.formId, formId),
+            eq(submissions.status, "draft"),
+          ),
+        )
+        .returning(SUBMISSION_COLUMNS)
+      if (updated) return updated
+    }
+
+    const [created] = await this.db
+      .insert(submissions)
+      .values({ formId, formVersionId, data, status: "draft" })
+      .returning(SUBMISSION_COLUMNS)
+    return created
+  }
+
+  async getDraft(
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionRow | null> {
+    const [row] = await this.db
+      .select(SUBMISSION_COLUMNS)
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.id, submissionId),
+          eq(submissions.formId, formId),
+          eq(submissions.status, "draft"),
+        ),
+      )
+    return row ?? null
+  }
+
+  async finalizeDraft(
+    formId: string,
+    submissionId: string,
+    formVersionId: string,
+    data: unknown,
+    submittedBy?: string | null,
+  ): Promise<SubmissionRow | null> {
+    const [row] = await this.db
+      .update(submissions)
+      .set({
+        data,
+        formVersionId,
+        submittedBy: submittedBy ?? null,
+        status: "submitted",
+        submittedAt: new Date(),
       })
-    // submittedAt is nullable at the column level (a submission can be
-    // saved as a draft first), but this insert always sets it.
-    return { ...row, submittedAt: row.submittedAt! }
+      .where(
+        and(
+          eq(submissions.id, submissionId),
+          eq(submissions.formId, formId),
+          eq(submissions.status, "draft"),
+        ),
+      )
+      .returning(SUBMISSION_COLUMNS)
+    return row ?? null
   }
 }

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -2,17 +2,52 @@ export interface SubmissionRow {
   id: string
   formId: string
   formVersionId: string
+  status: "draft" | "submitted"
+  data: unknown
   submittedBy: string | null
-  submittedAt: Date
+  submittedAt: Date | null
 }
 
 export interface SubmissionsRepository {
-  // Records a completed submission against a specific form version, so it
-  // always points at the exact schema it was captured against (US-1.3).
+  // Records a completed submission directly (no prior draft) against a
+  // specific form version, so it always points at the exact schema it was
+  // captured against (US-1.3).
   create(
     formId: string,
     formVersionId: string,
     data: unknown,
     submittedBy?: string | null,
   ): Promise<SubmissionRow>
+
+  // Creates or overwrites a draft (US-4.3): with no `submissionId`, inserts
+  // a new draft row; with one, overwrites that row's data in place --
+  // unless it no longer exists, belongs to a different form, or has
+  // already been finalized, in which case a fresh draft is inserted
+  // instead (a stale client-side reference shouldn't block saving).
+  // Never validated against required fields -- that's the point of a
+  // draft.
+  saveDraft(
+    formId: string,
+    formVersionId: string,
+    data: unknown,
+    submissionId?: string,
+  ): Promise<SubmissionRow>
+
+  // Fetches a draft by id, scoped to `formId`, so a respondent can resume
+  // filling it out. Returns null if it doesn't exist, belongs to a
+  // different form, or has already been finalized (US-4.3).
+  getDraft(formId: string, submissionId: string): Promise<SubmissionRow | null>
+
+  // Finalizes an existing draft in place: updates its data/version/status
+  // to "submitted" and stamps submittedAt. Returns null (rather than
+  // inserting) if the row doesn't exist, belongs to a different form, or
+  // was already finalized, so the caller can decide how to handle a stale
+  // reference (US-4.3).
+  finalizeDraft(
+    formId: string,
+    submissionId: string,
+    formVersionId: string,
+    data: unknown,
+    submittedBy?: string | null,
+  ): Promise<SubmissionRow | null>
 }

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -2,21 +2,36 @@ import type { FastifyPluginAsync } from "fastify"
 import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import { z } from "zod"
 import {
+  SaveDraftSubmissionSchema,
   SubmissionSchema,
   SubmissionValidationErrorSchema,
   SubmitFormSchema,
 } from "shared"
 import {
+  DraftNotFoundError,
   MissingRequiredFieldsError,
   NoActiveVersionError,
 } from "./services/submissions.js"
+import type { SubmissionRow } from "./repositories/submissions.js"
 import type { SubmissionsService } from "./services/submissions.js"
 
 const FormParamsSchema = z.object({ formId: z.string() })
+const DraftParamsSchema = z.object({
+  formId: z.string(),
+  submissionId: z.string(),
+})
 const ErrorResponseSchema = z.object({ message: z.string() })
 
+function serialize(submission: SubmissionRow) {
+  return {
+    ...submission,
+    data: submission.data as Record<string, unknown>,
+    submittedAt: submission.submittedAt?.toISOString() ?? null,
+  }
+}
+
 // One plugin per capability (US-0.5): submitting a completed form against
-// its active version.
+// its active version, and saving/resuming an in-progress draft (US-4.3).
 export function submissionsPlugin(
   service: SubmissionsService,
 ): FastifyPluginAsync {
@@ -42,11 +57,9 @@ export function submissionsPlugin(
             request.params.formId,
             request.body.data,
             request.body.submittedBy,
+            request.body.submissionId,
           )
-          return reply.code(201).send({
-            ...submission,
-            submittedAt: submission.submittedAt.toISOString(),
-          })
+          return reply.code(201).send(serialize(submission))
         } catch (error) {
           if (error instanceof MissingRequiredFieldsError) {
             return reply.code(400).send({
@@ -54,11 +67,64 @@ export function submissionsPlugin(
               missingFieldIds: error.missingFieldIds,
             })
           }
+          if (
+            error instanceof NoActiveVersionError ||
+            error instanceof DraftNotFoundError
+          ) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.post(
+      "/api/forms/:formId/submissions/draft",
+      {
+        schema: {
+          params: FormParamsSchema,
+          body: SaveDraftSubmissionSchema,
+          response: {
+            200: SubmissionSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const submission = await service.saveDraft(
+            request.params.formId,
+            request.body.data,
+            request.body.submissionId,
+          )
+          return reply.code(200).send(serialize(submission))
+        } catch (error) {
           if (error instanceof NoActiveVersionError) {
             return reply.code(404).send({ message: error.message })
           }
           throw error
         }
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/submissions/draft/:submissionId",
+      {
+        schema: {
+          params: DraftParamsSchema,
+          response: {
+            200: SubmissionSchema.nullable(),
+          },
+        },
+      },
+      async (request, reply) => {
+        const submission = await service.getDraft(
+          request.params.formId,
+          request.params.submissionId,
+        )
+        return reply
+          .code(200)
+          .send(submission ? serialize(submission) : null)
       },
     )
   }

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -16,6 +16,16 @@ export class MissingRequiredFieldsError extends Error {
   }
 }
 
+// Thrown when a submissionId passed to finalize doesn't resolve to an
+// existing, unfinalized draft for this form (US-4.3) -- it may have never
+// existed, belonged to a different form, or already been submitted.
+export class DraftNotFoundError extends Error {
+  constructor(formId: string, submissionId: string) {
+    super(`No draft ${submissionId} found for form ${formId}`)
+    this.name = "DraftNotFoundError"
+  }
+}
+
 function isEmpty(value: unknown): boolean {
   return value === undefined || value === null || value === ""
 }
@@ -28,11 +38,14 @@ export class SubmissionsService {
 
   // Validates the submission against the form's active version before
   // recording it, so a required field can never be silently skipped even
-  // if a client bypasses its own validation (US-3.5).
+  // if a client bypasses its own validation (US-3.5). If `submissionId`
+  // resumes an existing draft, that row is finalized in place rather than
+  // inserting a duplicate (US-4.3).
   async submit(
     formId: string,
     data: Record<string, unknown>,
     submittedBy?: string | null,
+    submissionId?: string,
   ) {
     const active = await this.formVersions.getActiveVersion(formId)
     if (!active) {
@@ -48,6 +61,42 @@ export class SubmissionsService {
       throw new MissingRequiredFieldsError(missingFieldIds)
     }
 
+    if (submissionId) {
+      const finalized = await this.repo.finalizeDraft(
+        formId,
+        submissionId,
+        active.id,
+        data,
+        submittedBy,
+      )
+      if (!finalized) {
+        throw new DraftNotFoundError(formId, submissionId)
+      }
+      return finalized
+    }
+
     return this.repo.create(formId, active.id, data, submittedBy)
+  }
+
+  // Saves an in-progress submission with no required-field validation --
+  // that's the whole point of a draft (US-4.3). Needs an active version to
+  // attach the draft to, same as a direct submission.
+  async saveDraft(
+    formId: string,
+    data: Record<string, unknown>,
+    submissionId?: string,
+  ) {
+    const active = await this.formVersions.getActiveVersion(formId)
+    if (!active) {
+      throw new NoActiveVersionError(formId)
+    }
+    return this.repo.saveDraft(formId, active.id, data, submissionId)
+  }
+
+  // Fetches a draft to resume filling it out. Returns null if it doesn't
+  // exist, belongs to a different form, or has already been finalized
+  // (US-4.3).
+  getDraft(formId: string, submissionId: string) {
+    return this.repo.getDraft(formId, submissionId)
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -45,11 +45,13 @@ export type {
 } from "./schemas/field.js"
 export {
   SubmitFormSchema,
+  SaveDraftSubmissionSchema,
   SubmissionSchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
   SubmitForm,
+  SaveDraftSubmission,
   Submission,
   SubmissionValidationError,
 } from "./schemas/submission.js"

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -9,16 +9,32 @@ export const SubmitFormSchema = z.object({
   // PublishFormVersionSchema's `publishedBy` -- there's no auth/user system
   // yet, so this is whatever the caller supplies (US-4.2).
   submittedBy: z.string().min(1).optional(),
+  // When resuming a draft (US-4.3), finalizes that exact row instead of
+  // inserting a new one. Omitted for a direct, one-shot submission.
+  submissionId: z.string().optional(),
 })
 
 export type SubmitForm = z.infer<typeof SubmitFormSchema>
+
+// A draft is never validated against required fields -- that's the whole
+// point of letting someone save an incomplete form and finish it later
+// (US-4.3). `submissionId` resumes (and overwrites) that exact draft row;
+// omitted, a new draft is created.
+export const SaveDraftSubmissionSchema = z.object({
+  data: z.record(z.string(), z.unknown()),
+  submissionId: z.string().optional(),
+})
+
+export type SaveDraftSubmission = z.infer<typeof SaveDraftSubmissionSchema>
 
 export const SubmissionSchema = z.object({
   id: z.string(),
   formId: z.string(),
   formVersionId: z.string(),
+  status: z.enum(["draft", "submitted"]),
+  data: z.record(z.string(), z.unknown()),
   submittedBy: z.string().nullable(),
-  submittedAt: z.iso.datetime(),
+  submittedAt: z.iso.datetime().nullable(),
 })
 
 export type Submission = z.infer<typeof SubmissionSchema>


### PR DESCRIPTION
## Summary
- Adds a draft-save path alongside the existing one-shot submit:
  - `POST /api/forms/:formId/submissions/draft` creates or overwrites a draft (no required-field validation)
  - `GET /api/forms/:formId/submissions/draft/:submissionId` resumes one
  - The existing `POST /api/forms/:formId/submissions` now accepts an optional `submissionId` to finalize that exact draft in place instead of inserting a duplicate row
- A stale `submissionId` (already finalized, wrong form, or never existed) falls back to inserting a fresh draft rather than erroring.
- The client remembers the current draft's id per form in `localStorage`, so reloading the page and returning to "Fill out" resumes exactly where the respondent left off; the entry clears once finalized.
- Draft submissions are excluded from reporting by construction: the `submissions.status` column (`draft` vs `submitted`) already existed in the schema for this; this is the first code path that actually produces a `draft` row, ready for any future reporting query (#20) to filter on.

Closes #17

## Test plan
- [x] `npm run typecheck`
- [x] Ran against a fresh Postgres instance via the API: saving a new draft, resuming it via GET, overwriting it in place, finalizing it (status flips to `submitted`, no duplicate row), and a stale draft-save id falling back to a new row
- [x] In the browser: partially filled a form, saved as draft, fully reloaded the page, confirmed the draft resumed with the saved value pre-filled, then submitted and confirmed the localStorage entry was cleared and exactly one `submitted` row exists in the DB (no duplicate)