### PR TITLE
US-5.1: View a submission

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,11 +4,15 @@ import { createForm, listForms } from "./api.js"
 import { FormBuilder } from "./FormBuilder.js"
 import { FormFill } from "./FormFill.js"
 import { RendererSpike } from "./renderer-spike/RendererSpike.js"
+import { SubmissionList } from "./SubmissionList.js"
+import { SubmissionView } from "./SubmissionView.js"
 
 type View =
   | { mode: "list" }
   | { mode: "build"; form: FormSummary }
   | { mode: "fill"; form: FormSummary }
+  | { mode: "submissions"; form: FormSummary }
+  | { mode: "view-submission"; form: FormSummary; submissionId: string }
 
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
@@ -52,6 +56,32 @@ export function App() {
     )
   }
 
+  if (view.mode === "submissions") {
+    const { form } = view
+    return (
+      <SubmissionList
+        formId={form.id}
+        formName={form.name}
+        onBack={() => setView({ mode: "list" })}
+        onView={(submissionId) =>
+          setView({ mode: "view-submission", form, submissionId })
+        }
+      />
+    )
+  }
+
+  if (view.mode === "view-submission") {
+    const { form } = view
+    return (
+      <SubmissionView
+        formId={form.id}
+        formName={form.name}
+        submissionId={view.submissionId}
+        onBack={() => setView({ mode: "submissions", form })}
+      />
+    )
+  }
+
   return (
     <main>
       <h1>form-builder</h1>
@@ -64,6 +94,12 @@ export function App() {
             </button>
             <button type="button" onClick={() => setView({ mode: "fill", form })}>
               Fill out
+            </button>
+            <button
+              type="button"
+              onClick={() => setView({ mode: "submissions", form })}
+            >
+              Submissions
             </button>
           </li>
         ))}

--- a/client/src/SubmissionList.tsx
+++ b/client/src/SubmissionList.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react"
+import type { SubmissionSummary } from "shared"
+import { listSubmissions } from "./api.js"
+
+interface SubmissionListProps {
+  formId: string
+  formName: string
+  onBack: () => void
+  onView: (submissionId: string) => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// A bare-bones, unfiltered list of a form's submissions -- just enough for
+// an admin to navigate to one and view it (US-5.1). Filtering by date
+// range/version and richer status/version columns are US-5.3's job.
+export function SubmissionList({
+  formId,
+  formName,
+  onBack,
+  onView,
+}: SubmissionListProps) {
+  const [submissions, setSubmissions] = useState<SubmissionSummary[]>([])
+  const [status, setStatus] = useState<Status>("loading")
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    listSubmissions(formId)
+      .then((result) => {
+        if (cancelled) return
+        setSubmissions(result)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId])
+
+  return (
+    <main>
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Submissions</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && <p role="alert">Couldn't load submissions.</p>}
+      {status === "ready" && submissions.length === 0 && (
+        <p>No submissions yet.</p>
+      )}
+      {status === "ready" && submissions.length > 0 && (
+        <ul>
+          {submissions.map((submission) => (
+            <li key={submission.id} className="form-list__item">
+              <span>
+                {submission.status === "draft" ? "Draft" : "Submitted"} —{" "}
+                {new Date(
+                  submission.submittedAt ?? submission.createdAt,
+                ).toLocaleString()}
+              </span>
+              <button type="button" onClick={() => onView(submission.id)}>
+                View
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/client/src/SubmissionView.tsx
+++ b/client/src/SubmissionView.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import type { SubmissionDetail } from "shared"
+import { getSubmission } from "./api.js"
+import { toJsonSchema } from "./schema/toJsonSchema.js"
+
+interface SubmissionViewProps {
+  formId: string
+  formName: string
+  submissionId: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// Renders a previously captured submission read-only, against the exact
+// schema version it was captured with rather than the form's current
+// active version -- so it still renders correctly even after the form has
+// since been republished with a different structure (US-5.1).
+export function SubmissionView({
+  formId,
+  formName,
+  submissionId,
+  onBack,
+}: SubmissionViewProps) {
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null)
+  const [status, setStatus] = useState<Status>("loading")
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getSubmission(formId, submissionId)
+      .then((result) => {
+        if (cancelled) return
+        setSubmission(result)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId, submissionId])
+
+  const { schema, uiSchema } = useMemo(
+    () => toJsonSchema(submission?.schema ?? { fields: [] }),
+    [submission],
+  )
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Submission</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load this submission.</p>
+      )}
+
+      {status === "ready" && submission && (
+        <>
+          <p>
+            Captured against version {submission.formVersionNumber} —{" "}
+            {submission.status === "draft" ? "draft" : "submitted"}
+            {submission.submittedAt &&
+              ` on ${new Date(submission.submittedAt).toLocaleString()}`}
+          </p>
+          <JsonForms
+            schema={schema}
+            uischema={uiSchema}
+            data={submission.data}
+            renderers={vanillaRenderers}
+            cells={vanillaCells}
+            readonly
+          />
+        </>
+      )}
+    </main>
+  )
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -4,6 +4,8 @@ import type {
   FormSummary,
   FormVersion,
   Submission,
+  SubmissionDetail,
+  SubmissionSummary,
   SubmissionValidationError,
 } from "shared"
 
@@ -108,5 +110,25 @@ export function getDraftSubmission(
 export function getPublishedFieldIds(formId: string): Promise<string[]> {
   return fetch(`/api/forms/${formId}/published-field-ids`).then((res) =>
     json<string[]>(res),
+  )
+}
+
+// A bare-bones list of a form's submissions, just enough to navigate to
+// one (US-5.1). Filtering/richer columns are US-5.3's job.
+export function listSubmissions(formId: string): Promise<SubmissionSummary[]> {
+  return fetch(`/api/forms/${formId}/submissions`).then((res) =>
+    json<SubmissionSummary[]>(res),
+  )
+}
+
+// Fetches one submission together with the exact schema version it was
+// captured against, so it renders correctly even if the form has since
+// been republished with a different structure (US-5.1).
+export function getSubmission(
+  formId: string,
+  submissionId: string,
+): Promise<SubmissionDetail> {
+  return fetch(`/api/forms/${formId}/submissions/${submissionId}`).then(
+    (res) => json<SubmissionDetail>(res),
   )
 }

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,7 +1,12 @@
-import { and, eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
-import { submissions } from "../../../db/schema.js"
-import type { SubmissionRow, SubmissionsRepository } from "./submissions.js"
+import { formVersions, submissions } from "../../../db/schema.js"
+import type {
+  SubmissionDetailRow,
+  SubmissionRow,
+  SubmissionsRepository,
+  SubmissionSummaryRow,
+} from "./submissions.js"
 
 const SUBMISSION_COLUMNS = {
   id: submissions.id,
@@ -105,6 +110,35 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
         ),
       )
       .returning(SUBMISSION_COLUMNS)
+    return row ?? null
+  }
+
+  async listByForm(formId: string): Promise<SubmissionSummaryRow[]> {
+    return this.db
+      .select({
+        id: submissions.id,
+        status: submissions.status,
+        createdAt: submissions.createdAt,
+        submittedAt: submissions.submittedAt,
+      })
+      .from(submissions)
+      .where(eq(submissions.formId, formId))
+      .orderBy(desc(submissions.createdAt))
+  }
+
+  async getById(
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionDetailRow | null> {
+    const [row] = await this.db
+      .select({
+        ...SUBMISSION_COLUMNS,
+        formVersionNumber: formVersions.version,
+        schema: formVersions.schema,
+      })
+      .from(submissions)
+      .innerJoin(formVersions, eq(submissions.formVersionId, formVersions.id))
+      .where(and(eq(submissions.id, submissionId), eq(submissions.formId, formId)))
     return row ?? null
   }
 }

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -8,6 +8,21 @@ export interface SubmissionRow {
   submittedAt: Date | null
 }
 
+export interface SubmissionSummaryRow {
+  id: string
+  status: "draft" | "submitted"
+  createdAt: Date
+  submittedAt: Date | null
+}
+
+export interface SubmissionDetailRow extends SubmissionRow {
+  // The version's own number and schema at the time this submission was
+  // captured, joined in so it renders correctly even if the form has
+  // since been republished with a different structure (US-5.1).
+  formVersionNumber: number
+  schema: unknown
+}
+
 export interface SubmissionsRepository {
   // Records a completed submission directly (no prior draft) against a
   // specific form version, so it always points at the exact schema it was
@@ -50,4 +65,17 @@ export interface SubmissionsRepository {
     data: unknown,
     submittedBy?: string | null,
   ): Promise<SubmissionRow | null>
+
+  // A bare-bones list of every submission (draft and submitted) for a
+  // form, most recent first -- just enough to navigate to one (US-5.1).
+  // Filtering/richer columns are US-5.3's job.
+  listByForm(formId: string): Promise<SubmissionSummaryRow[]>
+
+  // Fetches one submission together with the version it targets, scoped
+  // to `formId` so a submission id from another form can't be looked up
+  // (US-5.1). Returns null if no match.
+  getById(
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionDetailRow | null>
 }

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -3,20 +3,26 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import { z } from "zod"
 import {
   SaveDraftSubmissionSchema,
+  SubmissionDetailSchema,
+  SubmissionListSchema,
   SubmissionSchema,
   SubmissionValidationErrorSchema,
   SubmitFormSchema,
+  type FormSchema,
 } from "shared"
 import {
   DraftNotFoundError,
   MissingRequiredFieldsError,
   NoActiveVersionError,
 } from "./services/submissions.js"
-import type { SubmissionRow } from "./repositories/submissions.js"
+import type {
+  SubmissionDetailRow,
+  SubmissionRow,
+} from "./repositories/submissions.js"
 import type { SubmissionsService } from "./services/submissions.js"
 
 const FormParamsSchema = z.object({ formId: z.string() })
-const DraftParamsSchema = z.object({
+const SubmissionParamsSchema = z.object({
   formId: z.string(),
   submissionId: z.string(),
 })
@@ -27,6 +33,16 @@ function serialize(submission: SubmissionRow) {
     ...submission,
     data: submission.data as Record<string, unknown>,
     submittedAt: submission.submittedAt?.toISOString() ?? null,
+  }
+}
+
+function serializeDetail(submission: SubmissionDetailRow) {
+  return {
+    ...serialize(submission),
+    formVersionNumber: submission.formVersionNumber,
+    // The jsonb column is untyped at the DB layer; the app is the only
+    // writer and always writes the FormSchema shape.
+    schema: submission.schema as FormSchema,
   }
 }
 
@@ -111,7 +127,7 @@ export function submissionsPlugin(
       "/api/forms/:formId/submissions/draft/:submissionId",
       {
         schema: {
-          params: DraftParamsSchema,
+          params: SubmissionParamsSchema,
           response: {
             200: SubmissionSchema.nullable(),
           },
@@ -125,6 +141,49 @@ export function submissionsPlugin(
         return reply
           .code(200)
           .send(submission ? serialize(submission) : null)
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/submissions",
+      {
+        schema: {
+          params: FormParamsSchema,
+          response: { 200: SubmissionListSchema },
+        },
+      },
+      async (request) => {
+        const submissions = await service.listByForm(request.params.formId)
+        return submissions.map((submission) => ({
+          ...submission,
+          createdAt: submission.createdAt.toISOString(),
+          submittedAt: submission.submittedAt?.toISOString() ?? null,
+        }))
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/submissions/:submissionId",
+      {
+        schema: {
+          params: SubmissionParamsSchema,
+          response: {
+            200: SubmissionDetailSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const submission = await service.getById(
+          request.params.formId,
+          request.params.submissionId,
+        )
+        if (!submission) {
+          return reply.code(404).send({
+            message: `No submission ${request.params.submissionId} found for form ${request.params.formId}`,
+          })
+        }
+        return reply.code(200).send(serializeDetail(submission))
       },
     )
   }

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -99,4 +99,17 @@ export class SubmissionsService {
   getDraft(formId: string, submissionId: string) {
     return this.repo.getDraft(formId, submissionId)
   }
+
+  // A bare-bones list of a form's submissions, just enough to navigate to
+  // one (US-5.1).
+  listByForm(formId: string) {
+    return this.repo.listByForm(formId)
+  }
+
+  // Fetches one submission (draft or submitted) together with the exact
+  // version it targets, so it renders correctly even if the form has
+  // since been republished with a different structure (US-5.1).
+  getById(formId: string, submissionId: string) {
+    return this.repo.getById(formId, submissionId)
+  }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -47,11 +47,16 @@ export {
   SubmitFormSchema,
   SaveDraftSubmissionSchema,
   SubmissionSchema,
+  SubmissionSummarySchema,
+  SubmissionListSchema,
+  SubmissionDetailSchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
   SubmitForm,
   SaveDraftSubmission,
   Submission,
+  SubmissionSummary,
+  SubmissionDetail,
   SubmissionValidationError,
 } from "./schemas/submission.js"

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { FormSchemaSchema } from "./form-version.js"
 
 // Submitted values keyed by field id. Loosely typed for now, matching
 // FormSchemaSchema's own field looseness ahead of the full field-types
@@ -38,6 +39,30 @@ export const SubmissionSchema = z.object({
 })
 
 export type Submission = z.infer<typeof SubmissionSchema>
+
+// A bare-bones per-form list, just enough to navigate to one submission
+// (US-5.1) -- filtering by date range/version and showing richer columns
+// is US-5.3's job, not this one.
+export const SubmissionSummarySchema = z.object({
+  id: z.string(),
+  status: z.enum(["draft", "submitted"]),
+  createdAt: z.iso.datetime(),
+  submittedAt: z.iso.datetime().nullable(),
+})
+
+export type SubmissionSummary = z.infer<typeof SubmissionSummarySchema>
+
+export const SubmissionListSchema = z.array(SubmissionSummarySchema)
+
+// A single submission plus the exact schema (and version number) it was
+// captured against, so it always renders correctly even if the form has
+// since been republished with a different structure (US-5.1).
+export const SubmissionDetailSchema = SubmissionSchema.extend({
+  formVersionNumber: z.number().int(),
+  schema: FormSchemaSchema,
+})
+
+export type SubmissionDetail = z.infer<typeof SubmissionDetailSchema>
 
 // Returned when required fields are missing at submission time (US-3.5).
 export const SubmissionValidationErrorSchema = z.object({


### PR DESCRIPTION
## Summary
- Adds `GET /api/forms/:formId/submissions` (bare-bones list, most recent first) and `GET /api/forms/:formId/submissions/:submissionId` (joined with the exact `form_versions` row it targets, returning the version number and schema). Filtering by date range/version and richer status/version columns are #20's job, not this one -- this is just enough navigation to get to a submission.
- Renders a submission read-only with the same JSON Forms renderer used elsewhere (ADR-0003), against the schema it was **captured** against rather than the form's current active version.

Closes #18

## Test plan
- [x] `npm run typecheck`
- [x] Ran against a fresh Postgres instance: published a form (v1, a text field), recorded a submission, then completely restructured the form (v2, a dropdown with different fields) and republished
  - Via the API: `GET .../submissions/:id` still returns `formVersionNumber: 1` and the original schema, unaffected by v2
  - In the browser: the old submission renders its original text field with the original value ("Ada Lovelace"), disabled/read-only, labeled "Captured against version 1" -- even though the form is now on a completely different v2 structure