### PR TITLE
US-5.2: Edit a submission

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { createForm, listForms } from "./api.js"
 import { FormBuilder } from "./FormBuilder.js"
 import { FormFill } from "./FormFill.js"
 import { RendererSpike } from "./renderer-spike/RendererSpike.js"
+import { SubmissionEdit } from "./SubmissionEdit.js"
 import { SubmissionList } from "./SubmissionList.js"
 import { SubmissionView } from "./SubmissionView.js"
 
@@ -13,6 +14,7 @@ type View =
   | { mode: "fill"; form: FormSummary }
   | { mode: "submissions"; form: FormSummary }
   | { mode: "view-submission"; form: FormSummary; submissionId: string }
+  | { mode: "edit-submission"; form: FormSummary; submissionId: string }
 
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
@@ -66,6 +68,9 @@ export function App() {
         onView={(submissionId) =>
           setView({ mode: "view-submission", form, submissionId })
         }
+        onEdit={(submissionId) =>
+          setView({ mode: "edit-submission", form, submissionId })
+        }
       />
     )
   }
@@ -74,6 +79,18 @@ export function App() {
     const { form } = view
     return (
       <SubmissionView
+        formId={form.id}
+        formName={form.name}
+        submissionId={view.submissionId}
+        onBack={() => setView({ mode: "submissions", form })}
+      />
+    )
+  }
+
+  if (view.mode === "edit-submission") {
+    const { form } = view
+    return (
+      <SubmissionEdit
         formId={form.id}
         formName={form.name}
         submissionId={view.submissionId}

--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import type { SubmissionDetail, SubmissionEdit as SubmissionEditRecord } from "shared"
+import {
+  editSubmission,
+  getSubmission,
+  getSubmissionEdits,
+  SubmissionRejectedError,
+} from "./api.js"
+import { toJsonSchema } from "./schema/toJsonSchema.js"
+
+interface SubmissionEditProps {
+  formId: string
+  formName: string
+  submissionId: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// Lets an admin correct a previously submitted submission's values (US-5.2),
+// validated against the exact schema version it was captured with rather
+// than the form's current active version -- mirroring SubmissionView's
+// approach to rendering. Every save records the prior data as an audit-trail
+// row, shown below the form.
+export function SubmissionEdit({
+  formId,
+  formName,
+  submissionId,
+  onBack,
+}: SubmissionEditProps) {
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null)
+  const [edits, setEdits] = useState<SubmissionEditRecord[]>([])
+  const [status, setStatus] = useState<Status>("loading")
+  const [data, setData] = useState<Record<string, unknown>>({})
+  const [errors, setErrors] = useState<unknown[]>([])
+  const [showValidation, setShowValidation] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveMessage, setSaveMessage] = useState<string | null>(null)
+
+  function load() {
+    let cancelled = false
+    setStatus("loading")
+
+    Promise.all([
+      getSubmission(formId, submissionId),
+      getSubmissionEdits(formId, submissionId),
+    ])
+      .then(([submissionResult, editsResult]) => {
+        if (cancelled) return
+        setSubmission(submissionResult)
+        setData(submissionResult.data)
+        setEdits(editsResult)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }
+
+  useEffect(() => load(), [formId, submissionId])
+
+  const { schema, uiSchema } = useMemo(
+    () => toJsonSchema(submission?.schema ?? { fields: [] }),
+    [submission],
+  )
+
+  async function handleSave() {
+    if (errors.length > 0) {
+      setShowValidation(true)
+      return
+    }
+    setSaveError(null)
+    setSaveMessage(null)
+    try {
+      await editSubmission(formId, submissionId, data)
+      setSaveMessage("Saved.")
+      load()
+    } catch (error) {
+      if (error instanceof SubmissionRejectedError) {
+        setSaveError("Please fill out all required fields.")
+      } else {
+        setSaveError("Couldn't save these changes. Please try again.")
+      }
+    }
+  }
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Edit submission</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load this submission.</p>
+      )}
+
+      {status === "ready" && submission && (
+        <>
+          <p>Captured against version {submission.formVersionNumber}</p>
+          {saveError && <p role="alert">{saveError}</p>}
+          {saveMessage && <p>{saveMessage}</p>}
+          <JsonForms
+            schema={schema}
+            uischema={uiSchema}
+            data={data}
+            renderers={vanillaRenderers}
+            cells={vanillaCells}
+            validationMode={
+              showValidation ? "ValidateAndShow" : "ValidateAndHide"
+            }
+            onChange={({ data, errors }) => {
+              setData(data)
+              setErrors(errors ?? [])
+              setSaveMessage(null)
+            }}
+          />
+          <button type="button" onClick={handleSave}>
+            Save changes
+          </button>
+
+          <h2>Edit history</h2>
+          {edits.length === 0 && <p>No edits yet.</p>}
+          {edits.length > 0 && (
+            <ul>
+              {edits.map((edit) => (
+                <li key={edit.id}>
+                  {new Date(edit.editedAt).toLocaleString()}
+                  {edit.editedBy && ` — ${edit.editedBy}`}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </main>
+  )
+}

--- a/client/src/SubmissionList.tsx
+++ b/client/src/SubmissionList.tsx
@@ -7,6 +7,7 @@ interface SubmissionListProps {
   formName: string
   onBack: () => void
   onView: (submissionId: string) => void
+  onEdit: (submissionId: string) => void
 }
 
 type Status = "loading" | "ready" | "error"
@@ -19,6 +20,7 @@ export function SubmissionList({
   formName,
   onBack,
   onView,
+  onEdit,
 }: SubmissionListProps) {
   const [submissions, setSubmissions] = useState<SubmissionSummary[]>([])
   const [status, setStatus] = useState<Status>("loading")
@@ -67,6 +69,11 @@ export function SubmissionList({
               <button type="button" onClick={() => onView(submission.id)}>
                 View
               </button>
+              {submission.status === "submitted" && (
+                <button type="button" onClick={() => onEdit(submission.id)}>
+                  Edit
+                </button>
+              )}
             </li>
           ))}
         </ul>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,6 +5,7 @@ import type {
   FormVersion,
   Submission,
   SubmissionDetail,
+  SubmissionEdit,
   SubmissionSummary,
   SubmissionValidationError,
 } from "shared"
@@ -130,5 +131,36 @@ export function getSubmission(
 ): Promise<SubmissionDetail> {
   return fetch(`/api/forms/${formId}/submissions/${submissionId}`).then(
     (res) => json<SubmissionDetail>(res),
+  )
+}
+
+// Corrects a previously submitted submission's values, validated against
+// the exact schema version it was originally captured against rather than
+// the form's current active version (US-5.2).
+export async function editSubmission(
+  formId: string,
+  submissionId: string,
+  data: Record<string, unknown>,
+  editedBy?: string,
+): Promise<Submission> {
+  const res = await fetch(`/api/forms/${formId}/submissions/${submissionId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ data, editedBy }),
+  })
+  if (res.status === 400) {
+    const body = (await res.json()) as SubmissionValidationError
+    throw new SubmissionRejectedError(body.missingFieldIds)
+  }
+  return json<Submission>(res)
+}
+
+// The edit history for one submission, most recent first (US-5.2).
+export function getSubmissionEdits(
+  formId: string,
+  submissionId: string,
+): Promise<SubmissionEdit[]> {
+  return fetch(`/api/forms/${formId}/submissions/${submissionId}/edits`).then(
+    (res) => json<SubmissionEdit[]>(res),
   )
 }

--- a/server/src/db/migrations/0005_fancy_jimmy_woo.sql
+++ b/server/src/db/migrations/0005_fancy_jimmy_woo.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "submission_edits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"previous_data" jsonb NOT NULL,
+	"edited_by" text,
+	"edited_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "submission_edits" ADD CONSTRAINT "submission_edits_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/src/db/migrations/meta/0005_snapshot.json
+++ b/server/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,345 @@
+{
+  "id": "bbfca418-6e5b-455d-8558-a95cf5500a44",
+  "prevId": "fab279a4-10cb-42dc-b24b-da4e9c4c3e98",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_edits": {
+      "name": "submission_edits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_data": {
+          "name": "previous_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submission_edits_submission_id_submissions_id_fk": {
+          "name": "submission_edits_submission_id_submissions_id_fk",
+          "tableFrom": "submission_edits",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_form_id_forms_id_fk": {
+          "name": "submissions_form_id_forms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1788144339885,
       "tag": "0004_smiling_living_tribunal",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788157586421,
+      "tag": "0005_fancy_jimmy_woo",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -105,3 +105,24 @@ export const submissions = pgTable("submissions", {
     .defaultNow(),
   submittedAt: timestamp("submitted_at", { withTimezone: true }),
 })
+
+// An immutable audit trail of edits made to a submitted submission (US-5.2):
+// one row per edit, capturing the full prior data snapshot so a full history
+// of who changed what and when can be reconstructed, mirroring how
+// form_versions never mutates a published row in place.
+export const submissionEdits = pgTable("submission_edits", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  submissionId: uuid("submission_id")
+    .notNull()
+    .references(() => submissions.id, { onDelete: "cascade" }),
+  // The submission's data immediately before this edit was applied, so the
+  // edit history can show what changed rather than just that it did.
+  previousData: jsonb("previous_data").notNull(),
+  // Freeform identifier of who made this edit, mirroring `submittedBy` and
+  // `publishedBy` above -- there's no auth/user system yet, so this is
+  // whatever the caller supplies rather than a foreign key to a users table.
+  editedBy: text("edited_by"),
+  editedAt: timestamp("edited_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+})

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,8 +1,13 @@
 import { and, desc, eq } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
-import { formVersions, submissions } from "../../../db/schema.js"
+import {
+  formVersions,
+  submissionEdits,
+  submissions,
+} from "../../../db/schema.js"
 import type {
   SubmissionDetailRow,
+  SubmissionEditRow,
   SubmissionRow,
   SubmissionsRepository,
   SubmissionSummaryRow,
@@ -140,5 +145,53 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
       .innerJoin(formVersions, eq(submissions.formVersionId, formVersions.id))
       .where(and(eq(submissions.id, submissionId), eq(submissions.formId, formId)))
     return row ?? null
+  }
+
+  async edit(
+    formId: string,
+    submissionId: string,
+    data: unknown,
+    editedBy?: string | null,
+  ): Promise<SubmissionRow | null> {
+    return this.db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select({ data: submissions.data })
+        .from(submissions)
+        .where(
+          and(
+            eq(submissions.id, submissionId),
+            eq(submissions.formId, formId),
+            eq(submissions.status, "submitted"),
+          ),
+        )
+      if (!existing) return null
+
+      await tx.insert(submissionEdits).values({
+        submissionId,
+        previousData: existing.data,
+        editedBy: editedBy ?? null,
+      })
+
+      const [updated] = await tx
+        .update(submissions)
+        .set({ data, updatedAt: new Date() })
+        .where(eq(submissions.id, submissionId))
+        .returning(SUBMISSION_COLUMNS)
+      return updated
+    })
+  }
+
+  async listEdits(submissionId: string): Promise<SubmissionEditRow[]> {
+    return this.db
+      .select({
+        id: submissionEdits.id,
+        submissionId: submissionEdits.submissionId,
+        previousData: submissionEdits.previousData,
+        editedBy: submissionEdits.editedBy,
+        editedAt: submissionEdits.editedAt,
+      })
+      .from(submissionEdits)
+      .where(eq(submissionEdits.submissionId, submissionId))
+      .orderBy(desc(submissionEdits.editedAt))
   }
 }

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -23,6 +23,14 @@ export interface SubmissionDetailRow extends SubmissionRow {
   schema: unknown
 }
 
+export interface SubmissionEditRow {
+  id: string
+  submissionId: string
+  previousData: unknown
+  editedBy: string | null
+  editedAt: Date
+}
+
 export interface SubmissionsRepository {
   // Records a completed submission directly (no prior draft) against a
   // specific form version, so it always points at the exact schema it was
@@ -78,4 +86,19 @@ export interface SubmissionsRepository {
     formId: string,
     submissionId: string,
   ): Promise<SubmissionDetailRow | null>
+
+  // Overwrites a submitted submission's data in place and records the prior
+  // data as an audit-trail row in the same operation (US-5.2), so the two
+  // can never happen independently. Returns null if the row doesn't exist,
+  // belongs to a different form, or is still a draft (edits apply only to
+  // already-submitted submissions -- a draft is edited via saveDraft).
+  edit(
+    formId: string,
+    submissionId: string,
+    data: unknown,
+    editedBy?: string | null,
+  ): Promise<SubmissionRow | null>
+
+  // The edit history for one submission, most recent first (US-5.2).
+  listEdits(submissionId: string): Promise<SubmissionEditRow[]>
 }

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -2,8 +2,10 @@ import type { FastifyPluginAsync } from "fastify"
 import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import { z } from "zod"
 import {
+  EditSubmissionSchema,
   SaveDraftSubmissionSchema,
   SubmissionDetailSchema,
+  SubmissionEditListSchema,
   SubmissionListSchema,
   SubmissionSchema,
   SubmissionValidationErrorSchema,
@@ -14,9 +16,11 @@ import {
   DraftNotFoundError,
   MissingRequiredFieldsError,
   NoActiveVersionError,
+  SubmissionNotFoundError,
 } from "./services/submissions.js"
 import type {
   SubmissionDetailRow,
+  SubmissionEditRow,
   SubmissionRow,
 } from "./repositories/submissions.js"
 import type { SubmissionsService } from "./services/submissions.js"
@@ -43,6 +47,14 @@ function serializeDetail(submission: SubmissionDetailRow) {
     // The jsonb column is untyped at the DB layer; the app is the only
     // writer and always writes the FormSchema shape.
     schema: submission.schema as FormSchema,
+  }
+}
+
+function serializeEdit(edit: SubmissionEditRow) {
+  return {
+    ...edit,
+    previousData: edit.previousData as Record<string, unknown>,
+    editedAt: edit.editedAt.toISOString(),
   }
 }
 
@@ -184,6 +196,59 @@ export function submissionsPlugin(
           })
         }
         return reply.code(200).send(serializeDetail(submission))
+      },
+    )
+
+    typed.put(
+      "/api/forms/:formId/submissions/:submissionId",
+      {
+        schema: {
+          params: SubmissionParamsSchema,
+          body: EditSubmissionSchema,
+          response: {
+            200: SubmissionSchema,
+            400: SubmissionValidationErrorSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const submission = await service.edit(
+            request.params.formId,
+            request.params.submissionId,
+            request.body.data,
+            request.body.editedBy,
+          )
+          return reply.code(200).send(serialize(submission))
+        } catch (error) {
+          if (error instanceof MissingRequiredFieldsError) {
+            return reply.code(400).send({
+              message: error.message,
+              missingFieldIds: error.missingFieldIds,
+            })
+          }
+          if (error instanceof SubmissionNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
+      "/api/forms/:formId/submissions/:submissionId/edits",
+      {
+        schema: {
+          params: SubmissionParamsSchema,
+          response: { 200: SubmissionEditListSchema },
+        },
+      },
+      async (request) => {
+        const edits = await service.getEditHistory(
+          request.params.submissionId,
+        )
+        return edits.map(serializeEdit)
       },
     )
   }

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -26,8 +26,29 @@ export class DraftNotFoundError extends Error {
   }
 }
 
+// Thrown when a submissionId passed to edit doesn't resolve to an existing,
+// submitted submission for this form (US-5.2) -- it may have never existed,
+// belonged to a different form, or still be an in-progress draft (drafts are
+// edited via saveDraft, not this).
+export class SubmissionNotFoundError extends Error {
+  constructor(formId: string, submissionId: string) {
+    super(`No submitted submission ${submissionId} found for form ${formId}`)
+    this.name = "SubmissionNotFoundError"
+  }
+}
+
 function isEmpty(value: unknown): boolean {
   return value === undefined || value === null || value === ""
+}
+
+function requireFields(fields: Field[], data: Record<string, unknown>) {
+  const missingFieldIds = fields
+    .filter((field) => field.required && isEmpty(data[field.id]))
+    .map((field) => field.id)
+
+  if (missingFieldIds.length > 0) {
+    throw new MissingRequiredFieldsError(missingFieldIds)
+  }
 }
 
 export class SubmissionsService {
@@ -53,13 +74,7 @@ export class SubmissionsService {
     }
 
     const fields = (active.schema as { fields: Field[] }).fields
-    const missingFieldIds = fields
-      .filter((field) => field.required && isEmpty(data[field.id]))
-      .map((field) => field.id)
-
-    if (missingFieldIds.length > 0) {
-      throw new MissingRequiredFieldsError(missingFieldIds)
-    }
+    requireFields(fields, data)
 
     if (submissionId) {
       const finalized = await this.repo.finalizeDraft(
@@ -111,5 +126,37 @@ export class SubmissionsService {
   // since been republished with a different structure (US-5.1).
   getById(formId: string, submissionId: string) {
     return this.repo.getById(formId, submissionId)
+  }
+
+  // Corrects a previously submitted submission's values (US-5.2). Validates
+  // against the exact schema version the submission was originally captured
+  // against -- not the form's current active version, which may since have
+  // changed or been republished -- so an edit can never be rejected (or
+  // wrongly accepted) against rules that didn't apply when it was captured.
+  // Records the prior data as an audit-trail row in the same operation.
+  async edit(
+    formId: string,
+    submissionId: string,
+    data: Record<string, unknown>,
+    editedBy?: string | null,
+  ) {
+    const existing = await this.repo.getById(formId, submissionId)
+    if (!existing || existing.status !== "submitted") {
+      throw new SubmissionNotFoundError(formId, submissionId)
+    }
+
+    const fields = (existing.schema as { fields: Field[] }).fields
+    requireFields(fields, data)
+
+    const edited = await this.repo.edit(formId, submissionId, data, editedBy)
+    if (!edited) {
+      throw new SubmissionNotFoundError(formId, submissionId)
+    }
+    return edited
+  }
+
+  // The full edit history for one submission, most recent first (US-5.2).
+  getEditHistory(submissionId: string) {
+    return this.repo.listEdits(submissionId)
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -50,6 +50,9 @@ export {
   SubmissionSummarySchema,
   SubmissionListSchema,
   SubmissionDetailSchema,
+  EditSubmissionSchema,
+  SubmissionEditSchema,
+  SubmissionEditListSchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
@@ -58,5 +61,7 @@ export type {
   Submission,
   SubmissionSummary,
   SubmissionDetail,
+  EditSubmission,
+  SubmissionEdit,
   SubmissionValidationError,
 } from "./schemas/submission.js"

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -64,6 +64,33 @@ export const SubmissionDetailSchema = SubmissionSchema.extend({
 
 export type SubmissionDetail = z.infer<typeof SubmissionDetailSchema>
 
+// Corrects a previously submitted submission's values (US-5.2). Validated
+// against the exact schema version the submission was originally captured
+// against, not the form's current active version.
+export const EditSubmissionSchema = z.object({
+  data: z.record(z.string(), z.unknown()),
+  // Freeform identifier of who made the edit, mirroring `submittedBy` --
+  // there's no auth/user system yet, so this is whatever the caller
+  // supplies.
+  editedBy: z.string().min(1).optional(),
+})
+
+export type EditSubmission = z.infer<typeof EditSubmissionSchema>
+
+// One row of a submission's edit history (US-5.2): the data as it stood
+// immediately before that edit was applied, plus who made it and when.
+export const SubmissionEditSchema = z.object({
+  id: z.string(),
+  submissionId: z.string(),
+  previousData: z.record(z.string(), z.unknown()),
+  editedBy: z.string().nullable(),
+  editedAt: z.iso.datetime(),
+})
+
+export type SubmissionEdit = z.infer<typeof SubmissionEditSchema>
+
+export const SubmissionEditListSchema = z.array(SubmissionEditSchema)
+
 // Returned when required fields are missing at submission time (US-3.5).
 export const SubmissionValidationErrorSchema = z.object({
   message: z.string(),


### PR DESCRIPTION
## Summary
- Admins can edit a previously submitted submission's values, validated against the exact schema version it was originally captured with — not the form's current active version — so a later republish can never wrongly accept or reject an edit.
- Every edit records an immutable audit-trail row (`submission_edits`: prior data snapshot, `editedBy`, `editedAt`), following the same freeform-actor convention as `submittedBy`/`publishedBy`.
- New `PUT /api/forms/:formId/submissions/:submissionId` (edit) and `GET .../edits` (history) endpoints, `SubmissionEdit` client view with an inline edit-history list, and an "Edit" action on the submissions list (submitted rows only — drafts already have their own resume/save flow).

Closes richard-orchard-rewa/formbuilder#19

## Test plan
- [x] `npm run typecheck` passes in `shared`, `server`, `client`
- [x] `npm run build` passes in `shared`, `server`
- [x] Ran the full flow against a local Postgres (docker-compose): created a form, published v1, submitted a response, edited it via the UI, confirmed the DB `submissions.data` updated and `submission_edits` recorded the prior value
- [x] Republished the form with an unrelated v2 schema, then edited the old submission — confirmed it validates against its own captured v1 schema, not v2 (both missing-required-field rejection and successful edit verified via API)