### PR TITLE
US-3.2: Text area field

### DIFF
--- a/client/src/FieldInspector.tsx
+++ b/client/src/FieldInspector.tsx
@@ -121,6 +121,54 @@ export function FieldInspector({
         </>
       )}
 
+      {field.type === "textarea" && (
+        <>
+          <label className="field-inspector__field">
+            Placeholder
+            <input
+              type="text"
+              value={field.placeholder ?? ""}
+              onChange={(event) =>
+                onChange({
+                  ...field,
+                  placeholder: event.target.value || undefined,
+                })
+              }
+            />
+          </label>
+          <label className="field-inspector__field">
+            Max length
+            <input
+              type="number"
+              min={1}
+              value={field.maxLength ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  maxLength: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+          <label className="field-inspector__field">
+            Rows
+            <input
+              type="number"
+              min={1}
+              value={field.rows ?? ""}
+              onChange={(event) => {
+                const value = event.target.valueAsNumber
+                onChange({
+                  ...field,
+                  rows: Number.isNaN(value) ? undefined : value,
+                })
+              }}
+            />
+          </label>
+        </>
+      )}
+
       {(field.type === "dropdown" || field.type === "radio") && (
         <OptionsEditor field={field} onChange={onChange} />
       )}

--- a/client/src/FormFill.tsx
+++ b/client/src/FormFill.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
-import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
 import type { FormVersion } from "shared"
 import {
   getActiveVersion,
@@ -9,6 +9,7 @@ import {
   submitForm,
   SubmissionRejectedError,
 } from "./api.js"
+import { formCells } from "./schema/formCells.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface FormFillProps {
@@ -175,7 +176,7 @@ export function FormFill({ formId, formName, onBack }: FormFillProps) {
             uischema={uiSchema}
             data={data}
             renderers={vanillaRenderers}
-            cells={vanillaCells}
+            cells={formCells}
             validationMode={
               showValidation ? "ValidateAndShow" : "ValidateAndHide"
             }

--- a/client/src/FormPreview.tsx
+++ b/client/src/FormPreview.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
-import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
 import type { Field } from "shared"
+import { formCells } from "./schema/formCells.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface FormPreviewProps {
@@ -31,7 +32,7 @@ export function FormPreview({ fields }: FormPreviewProps) {
           uischema={uiSchema}
           data={data}
           renderers={vanillaRenderers}
-          cells={vanillaCells}
+          cells={formCells}
           onChange={({ data }) => setData(data)}
         />
       )}

--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
-import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
 import type { SubmissionDetail, SubmissionEdit as SubmissionEditRecord } from "shared"
 import {
   editSubmission,
@@ -8,6 +8,7 @@ import {
   getSubmissionEdits,
   SubmissionRejectedError,
 } from "./api.js"
+import { formCells } from "./schema/formCells.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface SubmissionEditProps {
@@ -114,7 +115,7 @@ export function SubmissionEdit({
             uischema={uiSchema}
             data={data}
             renderers={vanillaRenderers}
-            cells={vanillaCells}
+            cells={formCells}
             validationMode={
               showValidation ? "ValidateAndShow" : "ValidateAndHide"
             }

--- a/client/src/SubmissionView.tsx
+++ b/client/src/SubmissionView.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
-import { vanillaCells, vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
 import type { SubmissionDetail } from "shared"
 import { getSubmission } from "./api.js"
+import { formCells } from "./schema/formCells.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface SubmissionViewProps {
@@ -76,7 +77,7 @@ export function SubmissionView({
             uischema={uiSchema}
             data={submission.data}
             renderers={vanillaRenderers}
-            cells={vanillaCells}
+            cells={formCells}
             readonly
           />
         </>

--- a/client/src/schema/formCells.tsx
+++ b/client/src/schema/formCells.tsx
@@ -1,0 +1,44 @@
+import type { CellProps, RankedTester } from "@jsonforms/core"
+import { isMultiLineControl, rankWith } from "@jsonforms/core"
+import { withJsonFormsCellProps } from "@jsonforms/react"
+import { vanillaCells, withVanillaCellProps } from "@jsonforms/vanilla-renderers"
+
+// The vanilla renderer's own multi-line cell has no notion of a visible
+// row count at all -- it always renders a plain, unsized <textarea>. This
+// overrides it (higher rank) to additionally honor a `rows` UI schema
+// option, so a textarea field's configured row count (US-3.2) actually
+// renders.
+function TextAreaRowsCell(props: CellProps & { className?: string }) {
+  const { data, className, id, enabled, uischema, path, handleChange } = props
+  const options = uischema.options as
+    | { placeholder?: string; rows?: number }
+    | undefined
+  return (
+    <textarea
+      value={(data as string) || ""}
+      onChange={(event) =>
+        handleChange(
+          path,
+          event.target.value === "" ? undefined : event.target.value,
+        )
+      }
+      className={className}
+      id={id}
+      disabled={!enabled}
+      placeholder={options?.placeholder}
+      rows={options?.rows}
+    />
+  )
+}
+
+const textAreaRowsCellTester: RankedTester = rankWith(3, isMultiLineControl)
+
+// The cell registry to use everywhere the app renders a form from
+// `toJsonSchema`'s output, in place of `vanillaCells` alone.
+export const formCells = [
+  {
+    tester: textAreaRowsCellTester,
+    cell: withJsonFormsCellProps(withVanillaCellProps(TextAreaRowsCell)),
+  },
+  ...vanillaCells,
+]

--- a/client/src/schema/toJsonSchema.ts
+++ b/client/src/schema/toJsonSchema.ts
@@ -50,7 +50,11 @@ function toProperty(field: Field): JsonSchema7 {
         ...(field.maxLength ? { maxLength: field.maxLength } : {}),
       }
     case "textarea":
-      return { type: "string", title: field.label }
+      return {
+        type: "string",
+        title: field.label,
+        ...(field.maxLength ? { maxLength: field.maxLength } : {}),
+      }
     case "dropdown":
     case "radio":
       return {
@@ -90,7 +94,15 @@ function toUiSchemaElement(field: Field) {
   return {
     type: "Control" as const,
     scope: `#/properties/${field.id}`,
-    ...(field.type === "textarea" ? { options: { multi: true } } : {}),
+    ...(field.type === "textarea"
+      ? {
+          options: {
+            multi: true,
+            ...(field.placeholder ? { placeholder: field.placeholder } : {}),
+            ...(field.rows ? { rows: field.rows } : {}),
+          },
+        }
+      : {}),
     ...(field.type === "radio" ? { options: { format: "radio" } } : {}),
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -38,6 +38,7 @@ export type {
   FieldType,
   FieldOption,
   TextField,
+  TextAreaField,
   CheckboxField,
   RadioField,
   DateField,

--- a/shared/src/schemas/field.ts
+++ b/shared/src/schemas/field.ts
@@ -51,14 +51,20 @@ export const TextFieldSchema = z.object({
 
 export type TextField = z.infer<typeof TextFieldSchema>
 
-// Not yet configurable beyond a label and required — its own field-types
-// epic issue (US-3.2) extends this.
+// US-3.2: a multi-line text field for longer free text (e.g. notes).
 export const TextAreaFieldSchema = z.object({
   id: z.string(),
   type: z.literal("textarea"),
   label: z.string(),
+  placeholder: z.string().optional(),
   required: requiredFlag,
+  maxLength: z.number().int().positive().optional(),
+  // The textarea's visible height, in rows -- purely a rendering hint, not
+  // a constraint on how much can be entered (that's `maxLength`'s job).
+  rows: z.number().int().positive().optional(),
 })
+
+export type TextAreaField = z.infer<typeof TextAreaFieldSchema>
 
 // A labeled list of selectable values, shared by "dropdown" and "radio".
 export const FieldOptionSchema = z.object({


### PR DESCRIPTION
## Summary
- The text area field type is now configurable beyond label/required, mirroring the single-line text field: `placeholder`, `maxLength`, and `rows` (row count).
- `maxLength` is enforced the same way the text field's already is: as a JSON Schema constraint, validated client-side by JSON Forms/ajv.
- `placeholder` and `rows` are wired all the way through to the rendered `<textarea>`. The vanilla JSON Forms renderer's built-in multi-line cell supports `placeholder` but has no concept of row count at all, so this adds a small custom cell (`client/src/schema/formCells.tsx`) ranked above the built-in one that additionally honors a `rows` UI schema option — used everywhere the app renders a form (fill, preview, view, edit).
- Builder's Field settings panel gains Placeholder/Max length/Rows inputs for a selected text area field, matching the existing text field's inspector UI.

Closes richard-orchard-rewa/formbuilder#11

## Test plan
- [x] `npm run build` passes in `shared`
- [x] `npm run typecheck` passes in `shared`, `server`, `client`
- [x] Ran the full flow against a local Postgres (docker-compose): published a form with a text area field configured with a placeholder, `maxLength: 50`, `rows: 6`
- [x] Verified in the fill-out view: placeholder text renders, textarea renders at 6 visible rows (confirmed via `textarea.rows`), and typing over 50 characters triggers a "must NOT have more than 50 characters" validation error
- [x] Verified in the builder: selecting the field shows Placeholder/Max length/Rows inputs pre-filled with the saved values; editing Rows persists to the draft via autosave