### PR TITLE
US-0.3: Wire Zod-to-JSON-Schema conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ changing it, run `npm run db:generate -w server` to produce a new SQL
 migration under `server/src/db/migrations/`, then `npm run db:migrate -w server`
 to apply it.
 
+## Form contracts
+
+Zod is the single source of truth for a form's field definitions
+(`shared/src/schemas/field.ts`). `shared/src/json-schema.ts` converts those
+to JSON Schema (`toJsonSchema`) for the renderer, and builds the matching
+Zod schema a submission is validated against (`buildSubmissionSchema`) —
+see [ADR-0005](docs/adr/0005-zod-to-json-schema.md). The round trip is
+proven in `shared/src/json-schema.test.ts`:
+
+```bash
+npm run test -w shared
+```
+
 ## Layout
 
 - `shared/` — Zod schemas and types used by both `client` and `server`.

--- a/client/src/schema/toJsonSchema.ts
+++ b/client/src/schema/toJsonSchema.ts
@@ -1,92 +1,26 @@
-import type { JsonSchema7 } from "@jsonforms/core"
+import type { JsonSchema } from "@jsonforms/core"
 import type { Field, FormSchema } from "shared"
+import { toJsonSchema as fieldsToJsonSchema } from "shared"
 
 // Converts a FormSchema into the JSON Schema + UI Schema pair JSON Forms
 // renders from (ADR-0003) — used for both the builder's draft preview
 // (US-2.5) and the public fill-out view (US-4.1), so what an admin
-// previews is exactly what a respondent later fills out. This is a
-// stand-in for the generic Zod-to-JSON-Schema conversion US-0.3 will wire
-// up, covering every field type the canvas currently supports (US-3.1
-// through US-3.4); it's meant to be replaced by that conversion once it
-// lands.
+// previews is exactly what a respondent later fills out. The JSON Schema
+// half is `shared`'s own Zod-to-JSON-Schema conversion (US-0.3) -- Zod
+// stays the single source of truth for what a field's value looks like,
+// rather than this hand-authoring the same shape a second time. The UI
+// Schema half (layout/widget choice) has no Zod equivalent -- it's a JSON
+// Forms-specific, rendering-only concern -- so it's still built here.
 export function toJsonSchema(schema: FormSchema) {
-  const properties: Record<string, JsonSchema7> = {}
-  const required: string[] = []
-  const elements = schema.fields.map((field) => {
-    properties[field.id] = toProperty(field)
-    if (field.required) required.push(field.id)
-    return toUiSchemaElement(field)
-  })
-
   return {
-    schema: {
-      type: "object" as const,
-      properties,
-      ...(required.length > 0 ? { required } : {}),
-    },
+    // The shared conversion's output is a plain JSON Schema object; cast
+    // across the boundary to JSON Forms' own (structurally compatible)
+    // type rather than duplicating its shape here.
+    schema: fieldsToJsonSchema(schema.fields) as JsonSchema,
     uiSchema: {
       type: "VerticalLayout" as const,
-      elements,
+      elements: schema.fields.map(toUiSchemaElement),
     },
-  }
-}
-
-// A labeled list of options (dropdown/radio) becomes a `oneOf` of
-// const/title pairs rather than a plain `enum`, so the option's label
-// (not its raw value) is what renders.
-function toOneOf(options: { value: string; label: string }[]) {
-  return options.map((option) => ({
-    const: option.value,
-    title: option.label,
-  }))
-}
-
-function toProperty(field: Field): JsonSchema7 {
-  switch (field.type) {
-    case "text":
-      return {
-        type: "string",
-        title: field.label,
-        ...(field.maxLength ? { maxLength: field.maxLength } : {}),
-      }
-    case "textarea":
-      return {
-        type: "string",
-        title: field.label,
-        ...(field.maxLength ? { maxLength: field.maxLength } : {}),
-      }
-    case "dropdown":
-    case "radio":
-      return {
-        type: "string",
-        title: field.label,
-        ...(field.options.length > 0
-          ? { oneOf: toOneOf(field.options) }
-          : {}),
-        ...(field.defaultValue ? { default: field.defaultValue } : {}),
-      }
-    case "checkbox":
-      return {
-        type: "boolean",
-        title: field.label,
-        default: field.defaultChecked,
-      }
-    case "date":
-      return {
-        type: "string",
-        title: field.label,
-        format: "date",
-        ...(field.min ? { formatMinimum: field.min } : {}),
-        ...(field.max ? { formatMaximum: field.max } : {}),
-      }
-    case "number":
-      return {
-        type: "number",
-        title: field.label,
-        ...(field.min !== undefined ? { minimum: field.min } : {}),
-        ...(field.max !== undefined ? { maximum: field.max } : {}),
-        ...(field.step ? { multipleOf: field.step } : {}),
-      }
   }
 }
 

--- a/docs/adr/0005-zod-to-json-schema.md
+++ b/docs/adr/0005-zod-to-json-schema.md
@@ -1,0 +1,78 @@
+# ADR-0005: Zod-to-JSON-Schema conversion
+
+## Status
+
+Accepted
+
+## Context
+
+US-0.3 asks for `zod-to-json-schema` to be integrated into `shared/` so
+Zod stays the single source of truth for form contracts, with the JSON
+Schema output driving the form renderer chosen in ADR-0003 and a
+submission validated back against it.
+
+The `zod-to-json-schema` npm package predates Zod 4. Zod 4.4.3 (already the
+version pinned here, see ADR-0001) ships its own built-in converter,
+`z.toJSONSchema()`.
+
+## Decision
+
+Use Zod's built-in `z.toJSONSchema()`, wrapped by `toJsonSchema()` in
+[`shared/src/json-schema.ts`](../../shared/src/json-schema.ts), instead of
+the third-party `zod-to-json-schema` package named in the issue. This is a
+deliberate deviation from the literal acceptance criterion: the built-in
+converter needs no extra dependency and can't drift out of sync with
+whatever Zod features are used.
+
+`fieldValueSchema()` builds, from one of `shared`'s `Field` definitions,
+the Zod schema for what a valid *answer* to that field looks like (not the
+field definition itself). `buildSubmissionSchema()` assembles a form's
+full field list into one Zod object schema — the actual runtime source of
+truth for what a submission must look like, replacing the client's
+previous hand-authored, per-field-type JSON Schema builder. `toJsonSchema()`
+converts that to JSON Schema for the renderer.
+
+Two deviations from a bare `z.toJSONSchema()` call, both using its
+sanctioned extension points rather than post-processing its output:
+
+- **Option labels.** A `dropdown`/`radio` field's options need their label
+  (not just their value) to reach the renderer, so JSON Forms can show
+  "Great" instead of `"great"`. A plain `z.enum()` only carries values, so
+  each option becomes its own `z.literal(value).meta({ title: label })`
+  branch in a `z.union()` instead. Zod converts a union to `anyOf` by
+  default; JSON Forms specifically looks for `oneOf`
+  (`isOneOfEnumSchema`) to treat it as a labeled-enum control, so the
+  `override` callback renames a literal-only `anyOf` to `oneOf` on the way
+  out.
+- **Date range.** Zod has no native range check for an ISO date string
+  (`z.iso.date()`), but the renderer's bundled `ajv-formats` plugin
+  understands the non-standard `formatMinimum`/`formatMaximum` JSON Schema
+  keywords. `.meta()` merges arbitrary keys directly onto its schema's
+  JSON Schema output, so a date field's `min`/`max` are attached that way.
+
+Targets `draft-07` (`z.toJSONSchema`'s `target` option) rather than the
+default `draft-2020-12`, to match the draft the renderer's bundled Ajv
+instance (`@jsonforms/core`'s `createAjv`, a plain `Ajv` v8, not `Ajv2020`)
+validates against by default.
+
+The round trip — field definitions → Zod submission schema → JSON Schema →
+a submission validated against the JSON Schema with the same `Ajv` +
+`ajv-formats` setup the renderer bundles → the same submission re-validated
+by the original Zod schema — is proven in
+[`shared/src/json-schema.test.ts`](../../shared/src/json-schema.test.ts)
+(`npm run test -w shared`).
+
+## Consequences
+
+- `shared/src/json-schema.ts` exports `toJsonSchema()` and
+  `buildSubmissionSchema()`. `client/src/schema/toJsonSchema.ts` now calls
+  the former for a form's JSON Schema instead of hand-authoring it, and
+  only builds the JSON Forms-specific UI Schema (layout, widget choice)
+  itself — that half has no Zod equivalent.
+- `shared/`'s test tooling is `vitest`, with `ajv` and `ajv-formats` as
+  dev-only dependencies for the round-trip proof (not used at runtime by
+  `shared` itself — the app's actual renderer brings its own via
+  `@jsonforms/core`).
+- A new field type (US-3.4 onward) needs a matching `fieldValueSchema()`
+  case here, alongside its JSON Forms renderer (ADR-0003) and canvas/
+  inspector UI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,6 +1129,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1203,6 +1221,121 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abstract-logging": {
@@ -1284,6 +1417,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/atomic-sleep": {
@@ -1369,6 +1512,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001810",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
@@ -1389,6 +1542,23 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1418,6 +1588,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/client": {
@@ -1526,6 +1706,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dequal": {
@@ -1692,6 +1882,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1742,6 +1939,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-decode-uri-component": {
@@ -2136,6 +2353,13 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2144,6 +2368,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -2196,6 +2430,23 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pg": {
       "version": "8.23.0",
@@ -2673,6 +2924,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -2722,6 +2980,20 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2749,6 +3021,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -2784,6 +3076,20 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2799,6 +3105,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -3032,6 +3368,119 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -3155,7 +3604,10 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "typescript": "^5.8.3"
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "dev": "npm run build -w shared && concurrently -n server,client -c blue,green \"npm run dev -w server\" \"npm run dev -w client\"",
     "build": "npm run build -w shared && npm run build -w client && npm run build -w server",
-    "typecheck": "npm run typecheck -w shared && npm run typecheck -w client && npm run typecheck -w server"
+    "typecheck": "npm run typecheck -w shared && npm run typecheck -w client && npm run typecheck -w server",
+    "test": "npm run test -w shared"
   },
   "devDependencies": {
     "concurrently": "^9.2.1"

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "exports": {
     ".": {
@@ -18,6 +19,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2"
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -68,3 +68,4 @@ export type {
   SubmissionEdit,
   SubmissionValidationError,
 } from "./schemas/submission.js"
+export { buildSubmissionSchema, toJsonSchema } from "./json-schema.js"

--- a/shared/src/json-schema.test.ts
+++ b/shared/src/json-schema.test.ts
@@ -1,0 +1,152 @@
+import { createRequire } from "node:module"
+import { Ajv } from "ajv"
+import { describe, expect, it } from "vitest"
+import { buildSubmissionSchema, toJsonSchema } from "./json-schema.js"
+import type { Field } from "./schemas/field.js"
+
+// `ajv-formats` has no named export, and its default export doesn't type
+// correctly as a callable under this project's `moduleResolution:
+// "nodenext"` (a known rough edge for CJS packages without an `exports`
+// map) -- `createRequire` sidesteps that static-typing mismatch entirely,
+// since it resolves at runtime exactly like the app's own bundled
+// `@jsonforms/core` does via its own CJS `require("ajv-formats")`.
+const addFormats = createRequire(import.meta.url)("ajv-formats") as (
+  ajv: Ajv,
+) => void
+
+// Proves the full round trip Zod stays the source of truth for (US-0.3): a
+// form's field definitions -> a Zod submission schema -> a JSON Schema -> a
+// renderer collecting a submission validated against that JSON Schema ->
+// the same submission re-validated by the original Zod schema. Uses the
+// same `Ajv` + `ajv-formats` setup the app's own renderer bundles
+// (`@jsonforms/core`'s `createAjv`), so this proves the JSON Schema is
+// actually compatible with what will validate it at runtime, not just any
+// JSON Schema validator.
+describe("Zod-to-JSON-Schema round trip", () => {
+  const fields: Field[] = [
+    {
+      id: "fullName",
+      type: "text",
+      label: "Full name",
+      required: true,
+      maxLength: 40,
+    },
+    { id: "comments", type: "textarea", label: "Comments", required: false },
+    {
+      id: "satisfaction",
+      type: "dropdown",
+      label: "Satisfaction",
+      required: true,
+      options: [
+        { value: "poor", label: "Poor" },
+        { value: "great", label: "Great" },
+      ],
+    },
+    {
+      id: "subscribe",
+      type: "checkbox",
+      label: "Subscribe",
+      required: false,
+      defaultChecked: false,
+    },
+    {
+      id: "visitDate",
+      type: "date",
+      label: "Visit date",
+      required: true,
+      min: "2020-01-01",
+      max: "2029-12-31",
+    },
+    {
+      id: "rating",
+      type: "number",
+      label: "Rating",
+      required: false,
+      min: 1,
+      max: 5,
+    },
+  ]
+
+  const submissionSchema = buildSubmissionSchema(fields)
+  const jsonSchema = toJsonSchema(fields)
+  const ajv = new Ajv({ allErrors: true, strict: false })
+  addFormats(ajv)
+  const validateWithJsonSchema = ajv.compile(jsonSchema)
+
+  const validSubmission = {
+    fullName: "Jordan Lee",
+    satisfaction: "great",
+    subscribe: true,
+    visitDate: "2024-06-01",
+    rating: 4,
+  }
+
+  it("converts each field to the JSON Schema shape a renderer expects", () => {
+    expect(jsonSchema.properties).toMatchObject({
+      fullName: { type: "string", maxLength: 40, title: "Full name" },
+      comments: { type: "string", title: "Comments" },
+      satisfaction: {
+        oneOf: [
+          { const: "poor", title: "Poor" },
+          { const: "great", title: "Great" },
+        ],
+      },
+      subscribe: { type: "boolean", default: false },
+      visitDate: {
+        type: "string",
+        format: "date",
+        formatMinimum: "2020-01-01",
+        formatMaximum: "2029-12-31",
+      },
+      rating: { type: "number", minimum: 1, maximum: 5 },
+    })
+    expect(jsonSchema.required).toEqual(
+      expect.arrayContaining(["fullName", "satisfaction", "visitDate"]),
+    )
+    expect(jsonSchema.required).not.toContain("comments")
+    expect(jsonSchema.required).not.toContain("rating")
+  })
+
+  it("accepts a submission that satisfies every field, in both validators", () => {
+    expect(validateWithJsonSchema(validSubmission)).toBe(true)
+    expect(submissionSchema.safeParse(validSubmission).success).toBe(true)
+  })
+
+  it("rejects a submission missing a required field, in both validators", () => {
+    const { fullName, ...submission } = validSubmission
+
+    expect(validateWithJsonSchema(submission)).toBe(false)
+    expect(submissionSchema.safeParse(submission).success).toBe(false)
+  })
+
+  it("rejects a value outside a dropdown's options, in both validators", () => {
+    const submission = { ...validSubmission, satisfaction: "excellent" }
+
+    expect(validateWithJsonSchema(submission)).toBe(false)
+    expect(submissionSchema.safeParse(submission).success).toBe(false)
+  })
+
+  it("rejects text exceeding maxLength, in both validators", () => {
+    const submission = { ...validSubmission, fullName: "x".repeat(41) }
+
+    expect(validateWithJsonSchema(submission)).toBe(false)
+    expect(submissionSchema.safeParse(submission).success).toBe(false)
+  })
+
+  it("rejects a date outside its configured range, in both validators", () => {
+    const submission = { ...validSubmission, visitDate: "2019-12-31" }
+
+    // ajv-formats' formatMinimum/formatMaximum enforce the range; Zod has
+    // no native range check for an ISO date string, so this is the one
+    // constraint the JSON Schema validates that the original Zod schema
+    // doesn't re-check.
+    expect(validateWithJsonSchema(submission)).toBe(false)
+  })
+
+  it("rejects a number outside its min/max, in both validators", () => {
+    const submission = { ...validSubmission, rating: 6 }
+
+    expect(validateWithJsonSchema(submission)).toBe(false)
+    expect(submissionSchema.safeParse(submission).success).toBe(false)
+  })
+})

--- a/shared/src/json-schema.ts
+++ b/shared/src/json-schema.ts
@@ -1,0 +1,110 @@
+import { z } from "zod"
+import type { Field } from "./schemas/field.js"
+
+// Builds the Zod schema for one field's own answer value -- what a
+// submission's value for this field must look like -- from its definition
+// (`shared`'s `Field` union, the single source of truth for a form's
+// shape). This is the piece US-0.3 wires up: everything downstream (the
+// JSON Schema handed to the renderer, and the rule a submission is
+// validated against) is derived from this, not hand-authored per type.
+function fieldValueSchema(field: Field): z.ZodType {
+  const withRequired = <T extends z.ZodType>(schema: T) =>
+    field.required ? schema : schema.optional()
+
+  switch (field.type) {
+    case "text":
+    case "textarea": {
+      let schema = z.string()
+      if (field.maxLength) schema = schema.max(field.maxLength)
+      return withRequired(schema.meta({ title: field.label }))
+    }
+    case "dropdown":
+    case "radio": {
+      // A labeled union of literals (rather than a plain `z.enum`) so each
+      // option's label -- not just its value -- survives into the JSON
+      // Schema, for a renderer to show instead of the raw value.
+      let schema: z.ZodType =
+        field.options.length > 0
+          ? z.union(
+              field.options.map((option) =>
+                z.literal(option.value).meta({ title: option.label }),
+              ),
+            )
+          : z.string()
+      schema = schema.meta({ title: field.label })
+      if (field.defaultValue !== undefined) {
+        schema = schema.default(field.defaultValue)
+      }
+      return withRequired(schema)
+    }
+    case "checkbox":
+      return withRequired(
+        z
+          .boolean()
+          .meta({ title: field.label })
+          .default(field.defaultChecked),
+      )
+    case "date": {
+      const schema = z.iso.date().meta({
+        title: field.label,
+        // Not native Zod constraints (Zod has no date-range check for an
+        // ISO date string) -- merged onto the JSON Schema output as the
+        // `formatMinimum`/`formatMaximum` keywords ajv-formats understands,
+        // matching what the renderer's own validation enforces.
+        ...(field.min ? { formatMinimum: field.min } : {}),
+        ...(field.max ? { formatMaximum: field.max } : {}),
+      })
+      return withRequired(schema)
+    }
+    case "number": {
+      let schema = z.number()
+      if (field.min !== undefined) schema = schema.min(field.min)
+      if (field.max !== undefined) schema = schema.max(field.max)
+      if (field.step) schema = schema.multipleOf(field.step)
+      return withRequired(schema.meta({ title: field.label }))
+    }
+  }
+}
+
+// The single source of truth for what a valid submission to a given form
+// looks like. Built at runtime from the form's own field list (stored as
+// `form_versions.schema`) rather than a fixed set of columns, so this is
+// both the rule a submission is validated against and, via `toJsonSchema`
+// below, what a JSON Schema-driven renderer renders from (US-0.3).
+export function buildSubmissionSchema(fields: Field[]) {
+  const shape: Record<string, z.ZodType> = {}
+  for (const field of fields) {
+    shape[field.id] = fieldValueSchema(field)
+  }
+  return z.object(shape)
+}
+
+// Converts a Zod schema to JSON Schema using Zod's own built-in converter
+// (Zod 4+) rather than the third-party `zod-to-json-schema` package: it
+// needs no extra dependency and can't drift out of sync with whatever Zod
+// features are used. Targets draft-07 to match the draft the renderer's
+// bundled ajv validates against by default (Ajv 8's `Ajv` class, as
+// opposed to `Ajv2020`).
+//
+// A labeled option union (`dropdown`/`radio` above) converts to `anyOf` by
+// default; JSON Forms specifically looks for `oneOf` to treat it as an
+// enum-with-labels control (`isOneOfEnumSchema`), so every literal-union
+// branch is renamed from `anyOf` to `oneOf` on the way out.
+export function toJsonSchema(fields: Field[]) {
+  return z.toJSONSchema(buildSubmissionSchema(fields), {
+    target: "draft-07",
+    override: (ctx) => {
+      const json = ctx.jsonSchema as { anyOf?: unknown[]; oneOf?: unknown[] }
+      if (
+        Array.isArray(json.anyOf) &&
+        json.anyOf.every(
+          (branch) =>
+            typeof branch === "object" && branch !== null && "const" in branch,
+        )
+      ) {
+        json.oneOf = json.anyOf
+        delete json.anyOf
+      }
+    },
+  })
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "declaration": true,
+    "esModuleInterop": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary
- Adds `shared/src/json-schema.ts`: `buildSubmissionSchema(fields)` derives the Zod schema for a valid submission from a form's own `Field[]` definitions (the single source of truth), and `toJsonSchema(fields)` converts that to JSON Schema via Zod 4's built-in `z.toJSONSchema()` — see [ADR-0005](docs/adr/0005-zod-to-json-schema.md) for why the built-in converter was used over the third-party `zod-to-json-schema` package named in the issue, and how option labels (`oneOf`) and date ranges (`formatMinimum`/`formatMaximum`) are handled since they have no direct Zod equivalent.
- `client/src/schema/toJsonSchema.ts` now calls the shared conversion for the JSON Schema half instead of hand-authoring the same per-field-type shape a second time. It still builds the JSON Forms-specific UI Schema (layout/widget choice) itself, since that has no Zod equivalent.
- Adds `vitest` (plus `ajv`/`ajv-formats` as dev-only deps) to the `shared` workspace — the first test tooling in this repo — and a round-trip test (`shared/src/json-schema.test.ts`) proving: field definitions → Zod submission schema → JSON Schema → a submission validated against that JSON Schema with the same `Ajv` + `ajv-formats` setup the app's own renderer bundles → the same submission re-validated by the original Zod schema, across every field type (text, textarea, dropdown, checkbox, date, number).

Closes richard-orchard-rewa/formbuilder#23

## Test plan
- [x] `npm run typecheck` passes in `shared`, `client`, `server`
- [x] `npm run test -w shared` — 7/7 round-trip tests pass
- [x] `npm run build` passes across all three workspaces
- [x] Ran the full flow against a local Postgres (docker-compose): published a form covering every field type (text w/ maxLength, textarea, dropdown, checkbox, date w/ min/max, number w/ min/max/step, radio), confirmed in the browser that dropdown/radio option labels render correctly (not raw values), required-field validation still fires client-side, and a completed submission posts successfully (`201`) and is stored correctly
- [x] Confirmed server-side required-field rejection (`400` with `missingFieldIds`) still works unchanged