### PR TITLE
Add publish button and submission migration between form versions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import type { FormSummary } from "shared"
 import { createForm, listForms } from "./api.js"
 import { FormBuilder } from "./FormBuilder.js"
 import { FormFill } from "./FormFill.js"
+import { MigrationPlanner } from "./MigrationPlanner.js"
 import { RendererSpike } from "./renderer-spike/RendererSpike.js"
 import { SubmissionEdit } from "./SubmissionEdit.js"
 import { SubmissionList } from "./SubmissionList.js"
@@ -15,6 +16,13 @@ type View =
   | { mode: "submissions"; form: FormSummary }
   | { mode: "view-submission"; form: FormSummary; submissionId: string }
   | { mode: "edit-submission"; form: FormSummary; submissionId: string }
+  | {
+      mode: "migrate"
+      form: FormSummary
+      fromVersionId: string
+      fromVersionNumber: number
+      submissionId?: string
+    }
 
 export function App() {
   const [forms, setForms] = useState<FormSummary[]>([])
@@ -71,6 +79,29 @@ export function App() {
         onEdit={(submissionId) =>
           setView({ mode: "edit-submission", form, submissionId })
         }
+        onMigrate={(fromVersionId, fromVersionNumber, submissionId) =>
+          setView({
+            mode: "migrate",
+            form,
+            fromVersionId,
+            fromVersionNumber,
+            submissionId,
+          })
+        }
+      />
+    )
+  }
+
+  if (view.mode === "migrate") {
+    const { form } = view
+    return (
+      <MigrationPlanner
+        formId={form.id}
+        formName={form.name}
+        fromVersionId={view.fromVersionId}
+        fromVersionNumber={view.fromVersionNumber}
+        submissionId={view.submissionId}
+        onBack={() => setView({ mode: "submissions", form })}
       />
     )
   }

--- a/client/src/FormBuilder.tsx
+++ b/client/src/FormBuilder.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react"
 import { FIELD_TYPE_LABELS, type Field, type FieldType } from "shared"
-import { getDraft, getPublishedFieldIds, saveDraft } from "./api.js"
+import {
+  getActiveVersion,
+  getDraft,
+  getPublishedFieldIds,
+  NoDraftToPublishError,
+  publishForm,
+  saveDraft,
+} from "./api.js"
 import { FieldInspector } from "./FieldInspector.js"
 import { FieldPalette } from "./FieldPalette.js"
 import { FormCanvas } from "./FormCanvas.js"
@@ -61,14 +68,29 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     new Set(),
   )
   const [mode, setMode] = useState<"edit" | "preview">("edit")
+  const [publishState, setPublishState] = useState<
+    "idle" | "publishing" | "error"
+  >("idle")
+  const [publishError, setPublishError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setStatus("loading")
     getDraft(formId)
-      .then((draft) => {
+      .then(async (draft) => {
         if (cancelled) return
-        setFields(draft?.schema.fields ?? [])
+        // Once a version is published there's no draft row until the next
+        // edit creates one -- fall back to the active version's fields so
+        // resuming editing starts from the form as it currently stands
+        // rather than blank, which would otherwise silently drop every
+        // field the moment the next change is saved.
+        if (draft) {
+          setFields(draft.schema.fields)
+        } else {
+          const active = await getActiveVersion(formId)
+          if (cancelled) return
+          setFields(active?.schema.fields ?? [])
+        }
         setStatus("ready")
       })
       .catch(() => {
@@ -115,6 +137,26 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
     setSelectedId((current) => (current === fieldId ? null : current))
   }
 
+  function handlePublish() {
+    setPublishState("publishing")
+    setPublishError(null)
+    publishForm(formId)
+      .then(() => {
+        setPublishState("idle")
+        return getPublishedFieldIds(formId).then((ids) =>
+          setPublishedFieldIds(new Set(ids)),
+        )
+      })
+      .catch((error) => {
+        setPublishState("error")
+        setPublishError(
+          error instanceof NoDraftToPublishError
+            ? error.message
+            : "Couldn't publish this form.",
+        )
+      })
+  }
+
   const selectedField = fields.find((field) => field.id === selectedId) ?? null
 
   return (
@@ -132,11 +174,22 @@ export function FormBuilder({ formId, formName, onBack }: FormBuilderProps) {
             {mode === "edit" ? "Preview" : "Back to editing"}
           </button>
         )}
+        {status === "ready" && (
+          <button
+            type="button"
+            className="primary"
+            onClick={handlePublish}
+            disabled={publishState === "publishing"}
+          >
+            {publishState === "publishing" ? "Publishing…" : "Publish"}
+          </button>
+        )}
       </header>
 
       {status === "loading" && <p>Loading…</p>}
       {status === "error" && <p role="alert">Couldn't load this form.</p>}
       {saveError && <p role="alert">{saveError}</p>}
+      {publishError && <p role="alert">{publishError}</p>}
 
       {status === "ready" && mode === "preview" && (
         <FormPreview fields={fields} />

--- a/client/src/MigrationPlanner.tsx
+++ b/client/src/MigrationPlanner.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react"
+import { FIELD_TYPE_LABELS } from "shared"
+import type { FieldMapping, MigrationPlan } from "shared"
+import {
+  getActiveVersion,
+  getMigrationPlan,
+  migrateSubmission,
+  migrateVersion,
+} from "./api.js"
+
+interface MigrationPlannerProps {
+  formId: string
+  formName: string
+  fromVersionId: string
+  fromVersionNumber: number
+  // When set, migrates just this one submission; otherwise migrates every
+  // submitted submission captured against fromVersionId (US-6.1).
+  submissionId?: string
+  onBack: () => void
+}
+
+type Decision = { action: "drop" } | { action: "map"; targetFieldId: string }
+
+type Status = "loading" | "ready" | "error" | "no-target"
+
+// Lets an admin migrate submissions captured against an older form version
+// onto the form's current active version (US-6.1). A field that still
+// exists under the same id carries over automatically; anything else -- a
+// field the newer version dropped, or one an admin replaced with a
+// differently-typed field -- needs an explicit decision here, since
+// there's no reliable way to infer "field X was replaced by field Y" from
+// the schema alone (this app has no way to change a field's type in
+// place, so a "type change" always shows up as one field disappearing and
+// another appearing). Whatever isn't mapped, or can't be safely converted
+// once it is, is never silently discarded -- the server keeps it as legacy
+// data on the migrated submission.
+export function MigrationPlanner({
+  formId,
+  formName,
+  fromVersionId,
+  fromVersionNumber,
+  submissionId,
+  onBack,
+}: MigrationPlannerProps) {
+  const [status, setStatus] = useState<Status>("loading")
+  const [targetVersionId, setTargetVersionId] = useState<string | null>(null)
+  const [targetVersionNumber, setTargetVersionNumber] = useState<
+    number | null
+  >(null)
+  const [plan, setPlan] = useState<MigrationPlan | null>(null)
+  const [decisions, setDecisions] = useState<Record<string, Decision>>({})
+  const [running, setRunning] = useState(false)
+  const [runError, setRunError] = useState<string | null>(null)
+  const [resultMessage, setResultMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getActiveVersion(formId)
+      .then(async (active) => {
+        if (cancelled) return
+        if (!active) {
+          setStatus("no-target")
+          return
+        }
+        setTargetVersionId(active.id)
+        setTargetVersionNumber(active.version)
+        const result = await getMigrationPlan(formId, fromVersionId, active.id)
+        if (cancelled) return
+        setPlan(result)
+        setDecisions(
+          Object.fromEntries(
+            result.unmappedSourceFields.map((field) => [
+              field.id,
+              { action: "drop" as const },
+            ]),
+          ),
+        )
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId, fromVersionId])
+
+  function buildFieldMappings(): FieldMapping[] {
+    return Object.entries(decisions).map(([sourceFieldId, decision]) =>
+      decision.action === "map"
+        ? { sourceFieldId, action: "map", targetFieldId: decision.targetFieldId }
+        : { sourceFieldId, action: "drop" },
+    )
+  }
+
+  async function handleRun() {
+    if (!targetVersionId) return
+    setRunning(true)
+    setRunError(null)
+    setResultMessage(null)
+    try {
+      if (submissionId) {
+        const migrated = await migrateSubmission(
+          formId,
+          submissionId,
+          targetVersionId,
+          buildFieldMappings(),
+        )
+        setResultMessage(
+          migrated.status === "draft"
+            ? "Migrated, but saved as a draft — a newly required field couldn't be filled from the old data. Open it from the submissions list to finish it."
+            : "Migrated.",
+        )
+      } else {
+        const result = await migrateVersion(
+          formId,
+          fromVersionId,
+          targetVersionId,
+          buildFieldMappings(),
+        )
+        const parts = [`${result.migratedCount} submission(s) migrated.`]
+        if (result.needsFollowUpCount > 0) {
+          parts.push(
+            `${result.needsFollowUpCount} saved as drafts needing follow-up — a newly required field couldn't be filled.`,
+          )
+        }
+        if (result.alreadyMigratedCount > 0) {
+          parts.push(
+            `${result.alreadyMigratedCount} were already migrated and were skipped.`,
+          )
+        }
+        setResultMessage(parts.join(" "))
+      }
+    } catch {
+      setRunError("Couldn't run this migration. Please try again.")
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <main>
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>
+          {formName} — Migrate {submissionId ? "submission" : "submissions"} v
+          {fromVersionNumber} → v{targetVersionNumber ?? "?"}
+        </h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load the migration plan.</p>
+      )}
+      {status === "no-target" && (
+        <p role="alert">This form has no published version to migrate to.</p>
+      )}
+
+      {status === "ready" && plan && (
+        <>
+          <section>
+            <h2>Carried over automatically</h2>
+            {plan.autoMappedFields.length === 0 && (
+              <p>No fields are unchanged between these versions.</p>
+            )}
+            {plan.autoMappedFields.length > 0 && (
+              <ul>
+                {plan.autoMappedFields.map((field) => (
+                  <li key={field.id}>
+                    {field.label} ({FIELD_TYPE_LABELS[field.type]})
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section>
+            <h2>Needs a decision</h2>
+            {plan.unmappedSourceFields.length === 0 && (
+              <p>Every field carries over automatically — nothing to decide.</p>
+            )}
+            {plan.unmappedSourceFields.map((field) => {
+              const decision = decisions[field.id] ?? { action: "drop" as const }
+              return (
+                <label key={field.id} className="field-inspector__field">
+                  {field.label} ({FIELD_TYPE_LABELS[field.type]})
+                  <select
+                    value={
+                      decision.action === "map" ? decision.targetFieldId : ""
+                    }
+                    onChange={(event) => {
+                      const value = event.target.value
+                      setDecisions((current) => ({
+                        ...current,
+                        [field.id]: value
+                          ? { action: "map", targetFieldId: value }
+                          : { action: "drop" },
+                      }))
+                    }}
+                  >
+                    <option value="">Drop (keep as legacy data)</option>
+                    {plan.targetFields.map((target) => (
+                      <option key={target.id} value={target.id}>
+                        Map to "{target.label}" ({FIELD_TYPE_LABELS[target.type]})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )
+            })}
+          </section>
+
+          {runError && <p role="alert">{runError}</p>}
+          {resultMessage && <p>{resultMessage}</p>}
+
+          <button
+            type="button"
+            className="primary"
+            onClick={handleRun}
+            disabled={running}
+          >
+            {running ? "Migrating…" : "Run migration"}
+          </button>
+        </>
+      )}
+    </main>
+  )
+}

--- a/client/src/SubmissionList.tsx
+++ b/client/src/SubmissionList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import type { FormVersionSummary, SubmissionSummary } from "shared"
-import { listFormVersions, listSubmissions } from "./api.js"
+import { getActiveVersion, listFormVersions, listSubmissions } from "./api.js"
 
 interface SubmissionListProps {
   formId: string
@@ -8,6 +8,14 @@ interface SubmissionListProps {
   onBack: () => void
   onView: (submissionId: string) => void
   onEdit: (submissionId: string) => void
+  // Opens the migration planner for the given source version (US-6.1) --
+  // for one submission when `submissionId` is given, otherwise for every
+  // submitted submission captured against that version.
+  onMigrate: (
+    fromVersionId: string,
+    fromVersionNumber: number,
+    submissionId?: string,
+  ) => void
 }
 
 type Status = "loading" | "ready" | "error"
@@ -21,9 +29,13 @@ export function SubmissionList({
   onBack,
   onView,
   onEdit,
+  onMigrate,
 }: SubmissionListProps) {
   const [submissions, setSubmissions] = useState<SubmissionSummary[]>([])
   const [versions, setVersions] = useState<FormVersionSummary[]>([])
+  const [activeVersionNumber, setActiveVersionNumber] = useState<
+    number | null
+  >(null)
   const [status, setStatus] = useState<Status>("loading")
   const [from, setFrom] = useState("")
   const [to, setTo] = useState("")
@@ -33,7 +45,21 @@ export function SubmissionList({
     listFormVersions(formId)
       .then(setVersions)
       .catch(() => setVersions([]))
+    getActiveVersion(formId)
+      .then((active) => setActiveVersionNumber(active?.version ?? null))
+      .catch(() => setActiveVersionNumber(null))
   }, [formId])
+
+  // A submission can only be migrated forward, onto the form's current
+  // active version (US-6.1) -- there's no active version to target, or
+  // this submission already targets it.
+  function canMigrateFrom(versionNumber: number) {
+    return activeVersionNumber !== null && versionNumber !== activeVersionNumber
+  }
+
+  function versionIdFor(versionNumber: number) {
+    return versions.find((version) => version.version === versionNumber)?.id
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -101,6 +127,22 @@ export function SubmissionList({
         </label>
       </form>
 
+      {versionFilter !== "" && canMigrateFrom(Number(versionFilter)) && (
+        <p>
+          <button
+            type="button"
+            onClick={() => {
+              const fromVersionId = versionIdFor(Number(versionFilter))
+              if (fromVersionId) {
+                onMigrate(fromVersionId, Number(versionFilter))
+              }
+            }}
+          >
+            Migrate all v{versionFilter} submissions to v{activeVersionNumber}
+          </button>
+        </p>
+      )}
+
       {status === "loading" && <p>Loading…</p>}
       {status === "error" && <p role="alert">Couldn't load submissions.</p>}
       {status === "ready" && submissions.length === 0 && (
@@ -125,6 +167,26 @@ export function SubmissionList({
                   Edit
                 </button>
               )}
+              {submission.status === "submitted" &&
+                canMigrateFrom(submission.formVersionNumber) && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const fromVersionId = versionIdFor(
+                        submission.formVersionNumber,
+                      )
+                      if (fromVersionId) {
+                        onMigrate(
+                          fromVersionId,
+                          submission.formVersionNumber,
+                          submission.id,
+                        )
+                      }
+                    }}
+                  >
+                    Migrate to v{activeVersionNumber}
+                  </button>
+                )}
             </li>
           ))}
         </ul>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,9 +1,12 @@
 import type {
   Field,
+  FieldMapping,
   FormSchema,
   FormSummary,
   FormVersion,
   FormVersionSummary,
+  MigrationPlan,
+  MigrationResult,
   Submission,
   SubmissionDetail,
   SubmissionEdit,
@@ -53,6 +56,27 @@ export function getActiveVersion(formId: string): Promise<FormVersion | null> {
   return fetch(`/api/forms/${formId}/active`).then((res) =>
     json<FormVersion | null>(res),
   )
+}
+
+// Thrown when a form has no draft to publish (e.g. it was already published
+// with no further edits since).
+export class NoDraftToPublishError extends Error {
+  constructor() {
+    super("This form has no draft changes to publish")
+    this.name = "NoDraftToPublishError"
+  }
+}
+
+export async function publishForm(formId: string): Promise<FormVersion> {
+  const res = await fetch(`/api/forms/${formId}/publish`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  })
+  if (res.status === 409) {
+    throw new NoDraftToPublishError()
+  }
+  return json<FormVersion>(res)
 }
 
 // Thrown when the server rejects a submission for missing required fields
@@ -185,4 +209,50 @@ export function getSubmissionEdits(
   return fetch(`/api/forms/${formId}/submissions/${submissionId}/edits`).then(
     (res) => json<SubmissionEdit[]>(res),
   )
+}
+
+// The diff between two form versions an admin needs in order to build a
+// migration plan (US-6.1): which fields carry over automatically and which
+// need an explicit mapping decision.
+export function getMigrationPlan(
+  formId: string,
+  fromVersionId: string,
+  targetVersionId: string,
+): Promise<MigrationPlan> {
+  const query = new URLSearchParams({ fromVersionId, targetVersionId })
+  return fetch(
+    `/api/forms/${formId}/submissions/migration-plan?${query}`,
+  ).then((res) => json<MigrationPlan>(res))
+}
+
+// Migrates one submitted submission onto `targetVersionId` (US-6.1),
+// creating a new submission linked back to the original rather than
+// altering it in place.
+export function migrateSubmission(
+  formId: string,
+  submissionId: string,
+  targetVersionId: string,
+  fieldMappings: FieldMapping[],
+): Promise<Submission> {
+  return fetch(`/api/forms/${formId}/submissions/${submissionId}/migrate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ targetVersionId, fieldMappings }),
+  }).then((res) => json<Submission>(res))
+}
+
+// Migrates every submitted submission captured against `fromVersionId` onto
+// `targetVersionId` using the same field-mapping plan (US-6.1). Safe to
+// re-run -- submissions already migrated to that target are skipped.
+export function migrateVersion(
+  formId: string,
+  fromVersionId: string,
+  targetVersionId: string,
+  fieldMappings: FieldMapping[],
+): Promise<MigrationResult> {
+  return fetch(`/api/forms/${formId}/versions/${fromVersionId}/migrate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ targetVersionId, fieldMappings }),
+  }).then((res) => json<MigrationResult>(res))
 }

--- a/server/src/db/migrations/0006_demonic_whizzer.sql
+++ b/server/src/db/migrations/0006_demonic_whizzer.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "submissions" ADD COLUMN "legacy_data" jsonb;--> statement-breakpoint
+ALTER TABLE "submissions" ADD COLUMN "migrated_from_submission_id" uuid;--> statement-breakpoint
+ALTER TABLE "submissions" ADD CONSTRAINT "submissions_migrated_from_submission_id_submissions_id_fk" FOREIGN KEY ("migrated_from_submission_id") REFERENCES "public"."submissions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "submissions_one_migration_per_target_version" ON "submissions" USING btree ("migrated_from_submission_id","form_version_id") WHERE "submissions"."migrated_from_submission_id" is not null;

--- a/server/src/db/migrations/meta/0006_snapshot.json
+++ b/server/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,393 @@
+{
+  "id": "6b50f07f-29fc-4d5a-b106-c5b88713f1ec",
+  "prevId": "bbfca418-6e5b-455d-8558-a95cf5500a44",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_edits": {
+      "name": "submission_edits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_data": {
+          "name": "previous_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submission_edits_submission_id_submissions_id_fk": {
+          "name": "submission_edits_submission_id_submissions_id_fk",
+          "tableFrom": "submission_edits",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_from_submission_id": {
+          "name": "migrated_from_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_one_migration_per_target_version": {
+          "name": "submissions_one_migration_per_target_version",
+          "columns": [
+            {
+              "expression": "migrated_from_submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"migrated_from_submission_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_form_id_forms_id_fk": {
+          "name": "submissions_form_id_forms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_migrated_from_submission_id_submissions_id_fk": {
+          "name": "submissions_migrated_from_submission_id_submissions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "migrated_from_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788157586421,
       "tag": "0005_fancy_jimmy_woo",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1788252439111,
+      "tag": "0006_demonic_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -9,6 +9,7 @@ import {
   unique,
   uniqueIndex,
   check,
+  type AnyPgColumn,
 } from "drizzle-orm/pg-core"
 
 // A form is the container that owns a sequence of versions. Its own fields
@@ -81,30 +82,56 @@ export const formVersions = pgTable(
 // filter/group submissions by form directly (US-4.2). The submission's own
 // metadata lives in typed columns; the admin-defined, per-form answer set
 // itself has no fixed shape, so it lives in `data` (US-4.2).
-export const submissions = pgTable("submissions", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  formId: uuid("form_id")
-    .notNull()
-    .references(() => forms.id, { onDelete: "restrict" }),
-  formVersionId: uuid("form_version_id")
-    .notNull()
-    .references(() => formVersions.id, { onDelete: "restrict" }),
-  data: jsonb("data").notNull(),
-  status: text("status", { enum: ["draft", "submitted"] })
-    .notNull()
-    .default("draft"),
-  // Freeform identifier of who submitted this, mirroring `publishedBy`
-  // above -- there's no auth/user system yet, so this is whatever the
-  // caller supplies rather than a foreign key to a users table.
-  submittedBy: text("submitted_by"),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  submittedAt: timestamp("submitted_at", { withTimezone: true }),
-})
+export const submissions = pgTable(
+  "submissions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    formId: uuid("form_id")
+      .notNull()
+      .references(() => forms.id, { onDelete: "restrict" }),
+    formVersionId: uuid("form_version_id")
+      .notNull()
+      .references(() => formVersions.id, { onDelete: "restrict" }),
+    data: jsonb("data").notNull(),
+    // Values migrated from an older version whose field either no longer
+    // exists in this submission's version or couldn't be safely converted
+    // to its replacement's type (US-6.1). Keyed by the *original* field id
+    // so nothing a migration can't confidently place is ever silently
+    // discarded -- it just isn't part of the live form's data.
+    legacyData: jsonb("legacy_data"),
+    status: text("status", { enum: ["draft", "submitted"] })
+      .notNull()
+      .default("draft"),
+    // Freeform identifier of who submitted this, mirroring `publishedBy`
+    // above -- there's no auth/user system yet, so this is whatever the
+    // caller supplies rather than a foreign key to a users table.
+    submittedBy: text("submitted_by"),
+    // Set when this row was produced by migrating another submission onto a
+    // newer version (US-6.1) rather than being captured directly. The
+    // original submission is left untouched -- a version is immutable once
+    // published (ADR-0004) -- so a migration always creates a new row
+    // rather than converting one in place.
+    migratedFromSubmissionId: uuid("migrated_from_submission_id").references(
+      (): AnyPgColumn => submissions.id,
+      { onDelete: "set null" },
+    ),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }),
+  },
+  (table) => [
+    // A submission can only be migrated onto a given target version once --
+    // re-running a bulk migration (e.g. after fixing a mapping) must not
+    // create duplicate copies (US-6.1).
+    uniqueIndex("submissions_one_migration_per_target_version")
+      .on(table.migratedFromSubmissionId, table.formVersionId)
+      .where(sql`${table.migratedFromSubmissionId} is not null`),
+  ],
+)
 
 // An immutable audit trail of edits made to a submitted submission (US-5.2):
 // one row per edit, capturing the full prior data snapshot so a full history

--- a/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.drizzle.ts
@@ -174,4 +174,12 @@ export class DrizzleFormVersionsRepository implements FormVersionsRepository {
 
     return null
   }
+
+  async getVersionById(versionId: string): Promise<FormVersionRow | null> {
+    const [version] = await this.db
+      .select(VERSION_COLUMNS)
+      .from(formVersions)
+      .where(eq(formVersions.id, versionId))
+    return version ?? null
+  }
 }

--- a/server/src/modules/form-builder/repositories/form-versions.ts
+++ b/server/src/modules/form-builder/repositories/form-versions.ts
@@ -27,6 +27,15 @@ export class FormNotFoundError extends Error {
   }
 }
 
+// Thrown when a caller references a specific version by id (e.g. as a
+// migration's source or target, US-6.1) and it doesn't exist.
+export class FormVersionNotFoundError extends Error {
+  constructor(versionId: string) {
+    super(`No form version found with id ${versionId}`)
+    this.name = "FormVersionNotFoundError"
+  }
+}
+
 export interface FormVersionsRepository {
   // Publishes the form's current draft version: locks it as immutable,
   // assigns it the next version number, and supersedes whichever version
@@ -55,4 +64,10 @@ export interface FormVersionsRepository {
   // exist. This is what a submission is validated and recorded against
   // (US-3.5).
   getActiveVersion(formId: string): Promise<FormVersionRow | null>
+
+  // Returns one specific version by id (from any form), or null if it
+  // doesn't exist. Used when a caller already knows the exact version it
+  // wants -- e.g. migrating a submission onto a specific target version
+  // (US-6.1) -- rather than asking for "the draft" or "the active version".
+  getVersionById(versionId: string): Promise<FormVersionRow | null>
 }

--- a/server/src/modules/form-builder/services/form-versions.ts
+++ b/server/src/modules/form-builder/services/form-versions.ts
@@ -24,6 +24,10 @@ export class FormVersionsService {
     return this.repo.getActiveVersion(formId)
   }
 
+  getVersionById(versionId: string) {
+    return this.repo.getVersionById(versionId)
+  }
+
   // The field ids that appear in any version other than the current draft
   // (US-2.4): deleting one of these from the draft has downstream impact on
   // submissions already collected against a published version.

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -6,6 +6,7 @@ import {
   submissions,
 } from "../../../db/schema.js"
 import type {
+  CreateMigratedInput,
   SubmissionDetailRow,
   SubmissionEditRow,
   SubmissionListFilters,
@@ -20,6 +21,8 @@ const SUBMISSION_COLUMNS = {
   formVersionId: submissions.formVersionId,
   status: submissions.status,
   data: submissions.data,
+  legacyData: submissions.legacyData,
+  migratedFromSubmissionId: submissions.migratedFromSubmissionId,
   submittedBy: submissions.submittedBy,
   submittedAt: submissions.submittedAt,
 }
@@ -135,6 +138,7 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
         id: submissions.id,
         status: submissions.status,
         formVersionNumber: formVersions.version,
+        migratedFromSubmissionId: submissions.migratedFromSubmissionId,
         createdAt: submissions.createdAt,
         submittedAt: submissions.submittedAt,
       })
@@ -206,5 +210,54 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
       .from(submissionEdits)
       .where(eq(submissionEdits.submissionId, submissionId))
       .orderBy(desc(submissionEdits.editedAt))
+  }
+
+  async createMigrated(input: CreateMigratedInput): Promise<SubmissionRow> {
+    const [row] = await this.db
+      .insert(submissions)
+      .values({
+        formId: input.formId,
+        formVersionId: input.formVersionId,
+        data: input.data,
+        legacyData: input.legacyData,
+        status: input.status,
+        migratedFromSubmissionId: input.migratedFromSubmissionId,
+        submittedBy: input.migratedBy ?? null,
+        submittedAt: input.status === "submitted" ? new Date() : null,
+      })
+      .returning(SUBMISSION_COLUMNS)
+    return row
+  }
+
+  async findMigratedCopy(
+    submissionId: string,
+    formVersionId: string,
+  ): Promise<SubmissionRow | null> {
+    const [row] = await this.db
+      .select(SUBMISSION_COLUMNS)
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.migratedFromSubmissionId, submissionId),
+          eq(submissions.formVersionId, formVersionId),
+        ),
+      )
+    return row ?? null
+  }
+
+  async listSubmittedByVersion(
+    formId: string,
+    formVersionId: string,
+  ): Promise<{ id: string }[]> {
+    return this.db
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(
+        and(
+          eq(submissions.formId, formId),
+          eq(submissions.formVersionId, formVersionId),
+          eq(submissions.status, "submitted"),
+        ),
+      )
   }
 }

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -4,14 +4,30 @@ export interface SubmissionRow {
   formVersionId: string
   status: "draft" | "submitted"
   data: unknown
+  legacyData: unknown
+  migratedFromSubmissionId: string | null
   submittedBy: string | null
   submittedAt: Date | null
+}
+
+// Input to createMigrated (US-6.1): everything needed to record a
+// submission produced by migrating another one onto a newer version,
+// rather than being captured directly.
+export interface CreateMigratedInput {
+  formId: string
+  formVersionId: string
+  data: unknown
+  legacyData: unknown | null
+  status: "draft" | "submitted"
+  migratedFromSubmissionId: string
+  migratedBy?: string | null
 }
 
 export interface SubmissionSummaryRow {
   id: string
   status: "draft" | "submitted"
   formVersionNumber: number
+  migratedFromSubmissionId: string | null
   createdAt: Date
   submittedAt: Date | null
 }
@@ -115,4 +131,24 @@ export interface SubmissionsRepository {
 
   // The edit history for one submission, most recent first (US-5.2).
   listEdits(submissionId: string): Promise<SubmissionEditRow[]>
+
+  // Records a submission produced by migrating another one onto a newer
+  // version (US-6.1). The source submission is never touched -- this always
+  // inserts a new row, linked back via `migratedFromSubmissionId`.
+  createMigrated(input: CreateMigratedInput): Promise<SubmissionRow>
+
+  // Finds the submission (if any) already migrated from `submissionId` onto
+  // `formVersionId`, so a migration can be re-run safely without creating
+  // duplicates (US-6.1).
+  findMigratedCopy(
+    submissionId: string,
+    formVersionId: string,
+  ): Promise<SubmissionRow | null>
+
+  // The ids of every submitted (not draft) submission captured against one
+  // specific version, so a bulk migration knows what to migrate (US-6.1).
+  listSubmittedByVersion(
+    formId: string,
+    formVersionId: string,
+  ): Promise<{ id: string }[]>
 }

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -3,6 +3,10 @@ import type { ZodTypeProvider } from "fastify-type-provider-zod"
 import { z } from "zod"
 import {
   EditSubmissionSchema,
+  MigrateSubmissionRequestSchema,
+  MigrateVersionRequestSchema,
+  MigrationPlanSchema,
+  MigrationResultSchema,
   SaveDraftSubmissionSchema,
   SubmissionDetailSchema,
   SubmissionEditListSchema,
@@ -13,6 +17,7 @@ import {
   SubmitFormSchema,
   type FormSchema,
 } from "shared"
+import { FormVersionNotFoundError } from "../form-builder/repositories/form-versions.js"
 import {
   DraftNotFoundError,
   MissingRequiredFieldsError,
@@ -37,6 +42,7 @@ function serialize(submission: SubmissionRow) {
   return {
     ...submission,
     data: submission.data as Record<string, unknown>,
+    legacyData: (submission.legacyData as Record<string, unknown> | null) ?? null,
     submittedAt: submission.submittedAt?.toISOString() ?? null,
   }
 }
@@ -184,6 +190,34 @@ export function submissionsPlugin(
     )
 
     typed.get(
+      "/api/forms/:formId/submissions/migration-plan",
+      {
+        schema: {
+          params: FormParamsSchema,
+          querystring: z.object({
+            fromVersionId: z.string(),
+            targetVersionId: z.string(),
+          }),
+          response: { 200: MigrationPlanSchema, 404: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const plan = await service.getMigrationPlan(
+            request.query.fromVersionId,
+            request.query.targetVersionId,
+          )
+          return reply.code(200).send(plan)
+        } catch (error) {
+          if (error instanceof FormVersionNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.get(
       "/api/forms/:formId/submissions/:submissionId",
       {
         schema: {
@@ -258,6 +292,65 @@ export function submissionsPlugin(
           request.params.submissionId,
         )
         return edits.map(serializeEdit)
+      },
+    )
+
+    typed.post(
+      "/api/forms/:formId/submissions/:submissionId/migrate",
+      {
+        schema: {
+          params: SubmissionParamsSchema,
+          body: MigrateSubmissionRequestSchema,
+          response: { 200: SubmissionSchema, 404: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const submission = await service.migrateSubmission(
+            request.params.formId,
+            request.params.submissionId,
+            request.body.targetVersionId,
+            request.body.fieldMappings,
+            request.body.migratedBy,
+          )
+          return reply.code(200).send(serialize(submission))
+        } catch (error) {
+          if (
+            error instanceof SubmissionNotFoundError ||
+            error instanceof FormVersionNotFoundError
+          ) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
+      },
+    )
+
+    typed.post(
+      "/api/forms/:formId/versions/:fromVersionId/migrate",
+      {
+        schema: {
+          params: z.object({ formId: z.string(), fromVersionId: z.string() }),
+          body: MigrateVersionRequestSchema,
+          response: { 200: MigrationResultSchema, 404: ErrorResponseSchema },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const result = await service.migrateVersion(
+            request.params.formId,
+            request.params.fromVersionId,
+            request.body.targetVersionId,
+            request.body.fieldMappings,
+            request.body.migratedBy,
+          )
+          return reply.code(200).send(result)
+        } catch (error) {
+          if (error instanceof FormVersionNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
       },
     )
   }

--- a/server/src/modules/submissions/services/migration.ts
+++ b/server/src/modules/submissions/services/migration.ts
@@ -1,0 +1,145 @@
+import type { Field, FieldMapping, FieldType } from "shared"
+
+const TEXT_LIKE: FieldType[] = ["text", "textarea"]
+const CHOICE_LIKE: FieldType[] = ["dropdown", "radio"]
+
+export interface CoercionResult {
+  ok: boolean
+  value?: unknown
+}
+
+// Converts one field's stored value from its source type to a target
+// type, only where the conversion can't silently misrepresent the data
+// (US-6.1). This app's builder never changes a field's type in place --
+// changing type means deleting the old field and adding a new one -- so
+// there's no way to know two differently-typed fields are "the same
+// field" beyond an admin saying so via a FieldMapping; this function's
+// job is just to decide whether *that specific value*, once mapped, can
+// be trusted in its new shape. Anything not covered here (checkbox <->
+// number, an unparseable number, a dropdown value the target's options
+// don't contain, ...) is reported as not-ok so the caller preserves the
+// original value as legacy data instead of guessing.
+export function coerceValue(
+  value: unknown,
+  sourceField: Field,
+  targetField: Field,
+): CoercionResult {
+  if (value === undefined || value === null || value === "") {
+    return { ok: true, value }
+  }
+
+  if (sourceField.type === targetField.type) {
+    return { ok: true, value }
+  }
+
+  const source = sourceField.type
+  const target = targetField.type
+
+  if (TEXT_LIKE.includes(source) && TEXT_LIKE.includes(target)) {
+    return { ok: true, value }
+  }
+
+  if (source === "number" && TEXT_LIKE.includes(target)) {
+    return { ok: true, value: String(value) }
+  }
+  if (TEXT_LIKE.includes(source) && target === "number") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? { ok: true, value: parsed } : { ok: false }
+  }
+
+  if (source === "date" && TEXT_LIKE.includes(target)) {
+    return { ok: true, value }
+  }
+  if (TEXT_LIKE.includes(source) && target === "date") {
+    return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? { ok: true, value }
+      : { ok: false }
+  }
+
+  if (CHOICE_LIKE.includes(source) && TEXT_LIKE.includes(target)) {
+    return { ok: true, value }
+  }
+  if (
+    (TEXT_LIKE.includes(source) || CHOICE_LIKE.includes(source)) &&
+    CHOICE_LIKE.includes(target) &&
+    "options" in targetField
+  ) {
+    return targetField.options.some((option) => option.value === value)
+      ? { ok: true, value }
+      : { ok: false }
+  }
+
+  if (source === "checkbox" && TEXT_LIKE.includes(target)) {
+    return { ok: true, value: value ? "Yes" : "No" }
+  }
+
+  return { ok: false }
+}
+
+export interface MigratedData {
+  data: Record<string, unknown>
+  legacyData: Record<string, unknown> | null
+}
+
+// Builds the data payload for moving a submission from `sourceFields`' shape
+// to `targetFields`' (US-6.1). A field id present in both is always copied
+// verbatim -- a stable id guarantees a stable type in this app, so there's
+// no coercion risk. Every other source field needs an explicit
+// `fieldMappings` decision; a value that's dropped, unmapped, or whose
+// mapped coercion isn't safe is never discarded outright -- it's preserved
+// under `legacyData`, keyed by its original field id, so an admin can still
+// see and act on it later.
+export function migrateData(
+  sourceFields: Field[],
+  targetFields: Field[],
+  fieldMappings: FieldMapping[],
+  rawData: Record<string, unknown>,
+): MigratedData {
+  const targetFieldsById = new Map(targetFields.map((field) => [field.id, field]))
+  const mappingsBySourceId = new Map(
+    fieldMappings.map((mapping) => [mapping.sourceFieldId, mapping]),
+  )
+
+  const data: Record<string, unknown> = {}
+  const legacyData: Record<string, unknown> = {}
+
+  for (const field of sourceFields) {
+    const rawValue = rawData[field.id]
+    if (rawValue === undefined) continue
+
+    const identicalTarget = targetFieldsById.get(field.id)
+    if (identicalTarget) {
+      data[field.id] = rawValue
+      continue
+    }
+
+    const mapping = mappingsBySourceId.get(field.id)
+    if (!mapping || mapping.action === "drop") {
+      legacyData[field.id] = {
+        label: field.label,
+        type: field.type,
+        value: rawValue,
+      }
+      continue
+    }
+
+    const target = targetFieldsById.get(mapping.targetFieldId)
+    const coerced = target ? coerceValue(rawValue, field, target) : { ok: false }
+
+    if (target && coerced.ok) {
+      data[mapping.targetFieldId] = coerced.value
+    } else {
+      legacyData[field.id] = {
+        label: field.label,
+        type: field.type,
+        value: rawValue,
+        attemptedTargetFieldId: mapping.targetFieldId,
+      }
+    }
+  }
+
+  return {
+    data,
+    legacyData: Object.keys(legacyData).length > 0 ? legacyData : null,
+  }
+}

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -1,9 +1,11 @@
-import type { Field } from "shared"
+import type { Field, FieldMapping, FormSchema } from "shared"
+import { FormVersionNotFoundError } from "../../form-builder/repositories/form-versions.js"
 import type { FormVersionsService } from "../../form-builder/services/form-versions.js"
 import type {
   SubmissionListFilters,
   SubmissionsRepository,
 } from "../repositories/submissions.js"
+import { migrateData } from "./migration.js"
 
 export class NoActiveVersionError extends Error {
   constructor(formId: string) {
@@ -161,5 +163,142 @@ export class SubmissionsService {
   // The full edit history for one submission, most recent first (US-5.2).
   getEditHistory(submissionId: string) {
     return this.repo.listEdits(submissionId)
+  }
+
+  // Computes the diff an admin needs to decide a migration plan for
+  // (US-6.1): which of `fromVersionId`'s fields carry over to
+  // `targetVersionId` under the same id, and which need an explicit
+  // FieldMapping because they don't.
+  async getMigrationPlan(fromVersionId: string, targetVersionId: string) {
+    const [fromVersion, targetVersion] = await Promise.all([
+      this.formVersions.getVersionById(fromVersionId),
+      this.formVersions.getVersionById(targetVersionId),
+    ])
+    if (!fromVersion) throw new FormVersionNotFoundError(fromVersionId)
+    if (!targetVersion) throw new FormVersionNotFoundError(targetVersionId)
+
+    const sourceFields = (fromVersion.schema as FormSchema).fields
+    const targetFields = (targetVersion.schema as FormSchema).fields
+    const targetIds = new Set(targetFields.map((field) => field.id))
+
+    const autoMappedFields = sourceFields
+      .filter((field) => targetIds.has(field.id))
+      .map(({ id, label, type }) => ({ id, label, type }))
+    const unmappedSourceFields = sourceFields
+      .filter((field) => !targetIds.has(field.id))
+      .map(({ id, label, type }) => ({ id, label, type }))
+
+    return {
+      autoMappedFields,
+      unmappedSourceFields,
+      targetFields: targetFields.map(({ id, label, type }) => ({
+        id,
+        label,
+        type,
+      })),
+    }
+  }
+
+  // Migrates one submitted submission onto `targetVersionId` (US-6.1),
+  // applying `fieldMappings` for whatever fields don't carry over
+  // automatically. The source row is left untouched -- this always creates
+  // a new submission, linked back via `migratedFromSubmissionId` -- and
+  // re-running it for the same (submission, target version) pair returns
+  // the existing copy rather than creating a duplicate. The new row is
+  // saved as a draft rather than submitted if the mapping leaves one of the
+  // target version's required fields empty, so it surfaces in the
+  // submissions list as needing follow-up rather than silently passing
+  // validation it wouldn't otherwise have passed.
+  async migrateSubmission(
+    formId: string,
+    submissionId: string,
+    targetVersionId: string,
+    fieldMappings: FieldMapping[],
+    migratedBy?: string | null,
+  ) {
+    const existing = await this.repo.getById(formId, submissionId)
+    if (!existing || existing.status !== "submitted") {
+      throw new SubmissionNotFoundError(formId, submissionId)
+    }
+
+    const alreadyMigrated = await this.repo.findMigratedCopy(
+      submissionId,
+      targetVersionId,
+    )
+    if (alreadyMigrated) return alreadyMigrated
+
+    const targetVersion = await this.formVersions.getVersionById(targetVersionId)
+    if (!targetVersion) throw new FormVersionNotFoundError(targetVersionId)
+
+    const sourceFields = (existing.schema as FormSchema).fields
+    const targetFields = (targetVersion.schema as FormSchema).fields
+    const { data, legacyData } = migrateData(
+      sourceFields,
+      targetFields,
+      fieldMappings,
+      existing.data as Record<string, unknown>,
+    )
+
+    const missingRequired = targetFields.filter(
+      (field) => field.required && isEmpty(data[field.id]),
+    )
+
+    return this.repo.createMigrated({
+      formId,
+      formVersionId: targetVersionId,
+      data,
+      legacyData,
+      status: missingRequired.length > 0 ? "draft" : "submitted",
+      migratedFromSubmissionId: submissionId,
+      migratedBy,
+    })
+  }
+
+  // Migrates every submitted submission captured against `fromVersionId`
+  // onto `targetVersionId` using the same field-mapping plan (US-6.1).
+  // Submissions already migrated to that target are skipped rather than
+  // re-migrated, so this can be safely re-run (e.g. after new submissions
+  // arrive against the old version).
+  async migrateVersion(
+    formId: string,
+    fromVersionId: string,
+    targetVersionId: string,
+    fieldMappings: FieldMapping[],
+    migratedBy?: string | null,
+  ) {
+    const targetVersion = await this.formVersions.getVersionById(targetVersionId)
+    if (!targetVersion) throw new FormVersionNotFoundError(targetVersionId)
+
+    const sourceSubmissions = await this.repo.listSubmittedByVersion(
+      formId,
+      fromVersionId,
+    )
+
+    let migratedCount = 0
+    let needsFollowUpCount = 0
+    let alreadyMigratedCount = 0
+
+    for (const submission of sourceSubmissions) {
+      const existingCopy = await this.repo.findMigratedCopy(
+        submission.id,
+        targetVersionId,
+      )
+      if (existingCopy) {
+        alreadyMigratedCount++
+        continue
+      }
+
+      const migrated = await this.migrateSubmission(
+        formId,
+        submission.id,
+        targetVersionId,
+        fieldMappings,
+        migratedBy,
+      )
+      migratedCount++
+      if (migrated.status === "draft") needsFollowUpCount++
+    }
+
+    return { migratedCount, needsFollowUpCount, alreadyMigratedCount }
   }
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -68,4 +68,20 @@ export type {
   SubmissionEdit,
   SubmissionValidationError,
 } from "./schemas/submission.js"
+export {
+  FieldMappingSchema,
+  MigrationFieldSummarySchema,
+  MigrationPlanSchema,
+  MigrateSubmissionRequestSchema,
+  MigrateVersionRequestSchema,
+  MigrationResultSchema,
+} from "./schemas/migration.js"
+export type {
+  FieldMapping,
+  MigrationFieldSummary,
+  MigrationPlan,
+  MigrateSubmissionRequest,
+  MigrateVersionRequest,
+  MigrationResult,
+} from "./schemas/migration.js"
 export { buildSubmissionSchema, toJsonSchema } from "./json-schema.js"

--- a/shared/src/schemas/migration.ts
+++ b/shared/src/schemas/migration.ts
@@ -1,0 +1,76 @@
+import { z } from "zod"
+import { FieldTypeSchema } from "./field.js"
+
+// One decision for a source field that has no identical-id counterpart in
+// the target version: either map its value onto a specific target field
+// (subject to a type-safe coercion -- see the server's migration service)
+// or drop it, in which case its value is preserved as legacy data rather
+// than discarded outright (US-6.1). Fields whose id is unchanged between
+// versions never need a mapping -- they carry over automatically.
+export const FieldMappingSchema = z.discriminatedUnion("action", [
+  z.object({
+    sourceFieldId: z.string(),
+    action: z.literal("map"),
+    targetFieldId: z.string(),
+  }),
+  z.object({
+    sourceFieldId: z.string(),
+    action: z.literal("drop"),
+  }),
+])
+
+export type FieldMapping = z.infer<typeof FieldMappingSchema>
+
+// A field summary used to drive the migration-planning UI -- just enough to
+// label and type a mapping choice, not the field's full configuration.
+export const MigrationFieldSummarySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  type: FieldTypeSchema,
+})
+
+export type MigrationFieldSummary = z.infer<typeof MigrationFieldSummarySchema>
+
+// The computed diff between a source and target form version (US-6.1):
+// fields present under the same id in both (carried over automatically),
+// fields only in the source version (each needs an explicit FieldMapping
+// decision), and the target version's own fields (the candidates a source
+// field can be mapped onto).
+export const MigrationPlanSchema = z.object({
+  autoMappedFields: z.array(MigrationFieldSummarySchema),
+  unmappedSourceFields: z.array(MigrationFieldSummarySchema),
+  targetFields: z.array(MigrationFieldSummarySchema),
+})
+
+export type MigrationPlan = z.infer<typeof MigrationPlanSchema>
+
+export const MigrateSubmissionRequestSchema = z.object({
+  targetVersionId: z.string(),
+  fieldMappings: z.array(FieldMappingSchema).default([]),
+  migratedBy: z.string().min(1).optional(),
+})
+
+export type MigrateSubmissionRequest = z.infer<
+  typeof MigrateSubmissionRequestSchema
+>
+
+export const MigrateVersionRequestSchema = z.object({
+  targetVersionId: z.string(),
+  fieldMappings: z.array(FieldMappingSchema).default([]),
+  migratedBy: z.string().min(1).optional(),
+})
+
+export type MigrateVersionRequest = z.infer<typeof MigrateVersionRequestSchema>
+
+// The outcome of a bulk version migration (US-6.1): how many source
+// submissions were migrated, how many of those needed follow-up because a
+// newly required field couldn't be filled from the mapping (and so were
+// saved as drafts rather than submitted), and how many were left alone
+// because they were already migrated to this target version before.
+export const MigrationResultSchema = z.object({
+  migratedCount: z.number().int(),
+  needsFollowUpCount: z.number().int(),
+  alreadyMigratedCount: z.number().int(),
+})
+
+export type MigrationResult = z.infer<typeof MigrationResultSchema>

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -34,6 +34,14 @@ export const SubmissionSchema = z.object({
   formVersionId: z.string(),
   status: z.enum(["draft", "submitted"]),
   data: z.record(z.string(), z.unknown()),
+  // Values carried over from an older version by a migration (US-6.1) that
+  // either had no counterpart in this submission's version or couldn't be
+  // safely converted to its replacement's type -- kept visible rather than
+  // discarded, keyed by their original field id.
+  legacyData: z.record(z.string(), z.unknown()).nullable(),
+  // Set when this row was produced by migrating another submission onto a
+  // newer version (US-6.1), rather than being captured directly.
+  migratedFromSubmissionId: z.string().nullable(),
   submittedBy: z.string().nullable(),
   submittedAt: z.iso.datetime().nullable(),
 })
@@ -46,6 +54,7 @@ export const SubmissionSummarySchema = z.object({
   id: z.string(),
   status: z.enum(["draft", "submitted"]),
   formVersionNumber: z.number().int(),
+  migratedFromSubmissionId: z.string().nullable(),
   createdAt: z.iso.datetime(),
   submittedAt: z.iso.datetime().nullable(),
 })


### PR DESCRIPTION
## Summary
- Adds a Publish button to the form builder header, wiring up the existing (previously UI-less) `POST /api/forms/:formId/publish` endpoint.
- Adds submission migration (US-6.1): fields with a stable id carry over automatically between versions; any field that no longer exists needs an explicit per-field decision (map to a specific target field with a type-safe value coercion, or drop and keep as legacy data). Available per-submission and in bulk from the submissions list. Migration always creates a new linked submission rather than mutating the original, preserving ADR-0004's version immutability.
- Fixes a bug where the builder showed an empty canvas immediately after publishing (no draft row exists until the next edit), which would have silently wiped every field on the next save.

## Test plan
- [x] `npm run typecheck` passes across all workspaces
- [x] `npm run db:generate` / `npm run db:migrate` applied cleanly
- [x] Manually verified in-browser: publish v1 → submit → edit form (delete a field, add a differently-typed field) → publish v2 → submit → migrate the v1 submission (auto-mapped fields carried over, the removed field required an explicit decision)
- [x] Verified the coercion-failure path preserves data as `legacyData` rather than dropping it
- [x] Verified both single-submission and bulk migration are idempotent (re-running skips already-migrated submissions)
- [ ] Pre-existing unrelated test failures in `FieldInspector.test.tsx` / `FormPreview.test.tsx` (duplicate React copies) — confirmed present on the base branch too, not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)