### PR TITLE
US-6.1: SCD Type 2 trigger for submission edits

### DIFF
--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from "react"
 import { JsonForms } from "@jsonforms/react"
 import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
-import type { SubmissionDetail, SubmissionEdit as SubmissionEditRecord } from "shared"
+import type { SubmissionDetail, SubmissionHistory } from "shared"
 import {
   editSubmission,
   getSubmission,
-  getSubmissionEdits,
+  getSubmissionHistory,
   SubmissionRejectedError,
 } from "./api.js"
 import { formCells } from "./schema/formCells.js"
@@ -32,7 +32,7 @@ export function SubmissionEdit({
   onBack,
 }: SubmissionEditProps) {
   const [submission, setSubmission] = useState<SubmissionDetail | null>(null)
-  const [edits, setEdits] = useState<SubmissionEditRecord[]>([])
+  const [history, setHistory] = useState<SubmissionHistory[]>([])
   const [status, setStatus] = useState<Status>("loading")
   const [data, setData] = useState<Record<string, unknown>>({})
   const [errors, setErrors] = useState<unknown[]>([])
@@ -46,13 +46,13 @@ export function SubmissionEdit({
 
     Promise.all([
       getSubmission(formId, submissionId),
-      getSubmissionEdits(formId, submissionId),
+      getSubmissionHistory(formId, submissionId),
     ])
-      .then(([submissionResult, editsResult]) => {
+      .then(([submissionResult, historyResult]) => {
         if (cancelled) return
         setSubmission(submissionResult)
         setData(submissionResult.data)
-        setEdits(editsResult)
+        setHistory(historyResult)
         setStatus("ready")
       })
       .catch(() => {
@@ -130,13 +130,13 @@ export function SubmissionEdit({
           </button>
 
           <h2>Edit history</h2>
-          {edits.length === 0 && <p>No edits yet.</p>}
-          {edits.length > 0 && (
+          {history.length === 0 && <p>No edits yet.</p>}
+          {history.length > 0 && (
             <ul>
-              {edits.map((edit) => (
-                <li key={edit.id}>
-                  {new Date(edit.editedAt).toLocaleString()}
-                  {edit.editedBy && ` — ${edit.editedBy}`}
+              {history.map((entry) => (
+                <li key={entry.id}>
+                  {new Date(entry.activeTo).toLocaleString()}
+                  {entry.editedBy && ` — ${entry.editedBy}`}
                 </li>
               ))}
             </ul>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -9,7 +9,7 @@ import type {
   MigrationResult,
   Submission,
   SubmissionDetail,
-  SubmissionEdit,
+  SubmissionHistory,
   SubmissionListQuery,
   SubmissionSummary,
   SubmissionValidationError,
@@ -201,13 +201,14 @@ export async function editSubmission(
   return json<Submission>(res)
 }
 
-// The edit history for one submission, most recent first (US-5.2).
-export function getSubmissionEdits(
+// The audit-trail history for one submission, most recently superseded
+// first (US-5.2, US-6.1).
+export function getSubmissionHistory(
   formId: string,
   submissionId: string,
-): Promise<SubmissionEdit[]> {
-  return fetch(`/api/forms/${formId}/submissions/${submissionId}/edits`).then(
-    (res) => json<SubmissionEdit[]>(res),
+): Promise<SubmissionHistory[]> {
+  return fetch(`/api/forms/${formId}/submissions/${submissionId}/history`).then(
+    (res) => json<SubmissionHistory[]>(res),
   )
 }
 

--- a/server/src/db/migrations/0007_replace_submission_edits_with_history.sql
+++ b/server/src/db/migrations/0007_replace_submission_edits_with_history.sql
@@ -1,0 +1,18 @@
+DROP TABLE "submission_edits";--> statement-breakpoint
+CREATE TABLE "submission_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"form_id" uuid NOT NULL,
+	"form_version_id" uuid NOT NULL,
+	"data" jsonb NOT NULL,
+	"legacy_data" jsonb,
+	"status" text NOT NULL,
+	"submitted_by" text,
+	"migrated_from_submission_id" uuid,
+	"edited_by" text,
+	"active_from" timestamp with time zone NOT NULL,
+	"active_to" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "submission_history" ADD CONSTRAINT "submission_history_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "submission_history_submission_id" ON "submission_history" USING btree ("submission_id");

--- a/server/src/db/migrations/0008_submission_archive_trigger.sql
+++ b/server/src/db/migrations/0008_submission_archive_trigger.sql
@@ -1,0 +1,19 @@
+CREATE FUNCTION archive_submission_before_update() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO submission_history (
+    submission_id, form_id, form_version_id, data, legacy_data, status,
+    submitted_by, migrated_from_submission_id, edited_by, active_from, active_to
+  ) VALUES (
+    OLD.id, OLD.form_id, OLD.form_version_id, OLD.data, OLD.legacy_data, OLD.status,
+    OLD.submitted_by, OLD.migrated_from_submission_id,
+    NULLIF(current_setting('app.edited_by', true), ''), OLD.updated_at, now()
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TRIGGER submissions_archive_before_update
+BEFORE UPDATE ON submissions
+FOR EACH ROW
+WHEN (OLD.status = 'submitted' AND (OLD.data IS DISTINCT FROM NEW.data OR OLD.legacy_data IS DISTINCT FROM NEW.legacy_data))
+EXECUTE FUNCTION archive_submission_before_update();

--- a/server/src/db/migrations/meta/0007_snapshot.json
+++ b/server/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,450 @@
+{
+  "id": "448d7641-310c-49ed-80b2-b4b7606004c8",
+  "prevId": "6b50f07f-29fc-4d5a-b106-c5b88713f1ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_history": {
+      "name": "submission_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_from_submission_id": {
+          "name": "migrated_from_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_from": {
+          "name": "active_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_to": {
+          "name": "active_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "submission_history_submission_id": {
+          "name": "submission_history_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_history_submission_id_submissions_id_fk": {
+          "name": "submission_history_submission_id_submissions_id_fk",
+          "tableFrom": "submission_history",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_from_submission_id": {
+          "name": "migrated_from_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_one_migration_per_target_version": {
+          "name": "submissions_one_migration_per_target_version",
+          "columns": [
+            {
+              "expression": "migrated_from_submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"migrated_from_submission_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_form_id_forms_id_fk": {
+          "name": "submissions_form_id_forms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_migrated_from_submission_id_submissions_id_fk": {
+          "name": "submissions_migrated_from_submission_id_submissions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "migrated_from_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/0008_snapshot.json
+++ b/server/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,450 @@
+{
+  "id": "03936383-8953-4224-81a0-4b38434a5764",
+  "prevId": "448d7641-310c-49ed-80b2-b4b7606004c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.form_versions": {
+      "name": "form_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "form_versions_one_published_per_form": {
+          "name": "form_versions_one_published_per_form",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_versions\".\"status\" = 'published'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_versions_form_id_forms_id_fk": {
+          "name": "form_versions_form_id_forms_id_fk",
+          "tableFrom": "form_versions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_versions_form_id_version_key": {
+          "name": "form_versions_form_id_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "form_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "form_versions_published_at_matches_status": {
+          "name": "form_versions_published_at_matches_status",
+          "value": "(\"form_versions\".\"status\" = 'draft') = (\"form_versions\".\"published_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forms_slug_unique": {
+          "name": "forms_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission_history": {
+      "name": "submission_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_from_submission_id": {
+          "name": "migrated_from_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_by": {
+          "name": "edited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_from": {
+          "name": "active_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_to": {
+          "name": "active_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "submission_history_submission_id": {
+          "name": "submission_history_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_history_submission_id_submissions_id_fk": {
+          "name": "submission_history_submission_id_submissions_id_fk",
+          "tableFrom": "submission_history",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_version_id": {
+          "name": "form_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_by": {
+          "name": "submitted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "migrated_from_submission_id": {
+          "name": "migrated_from_submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submissions_one_migration_per_target_version": {
+          "name": "submissions_one_migration_per_target_version",
+          "columns": [
+            {
+              "expression": "migrated_from_submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "form_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"submissions\".\"migrated_from_submission_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_form_id_forms_id_fk": {
+          "name": "submissions_form_id_forms_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_form_version_id_form_versions_id_fk": {
+          "name": "submissions_form_version_id_form_versions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "form_versions",
+          "columnsFrom": [
+            "form_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "submissions_migrated_from_submission_id_submissions_id_fk": {
+          "name": "submissions_migrated_from_submission_id_submissions_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "migrated_from_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -50,6 +50,20 @@
       "when": 1788252439111,
       "tag": "0006_demonic_whizzer",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1788400000000,
+      "tag": "0007_replace_submission_edits_with_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788400100000,
+      "tag": "0008_submission_archive_trigger",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -8,6 +8,7 @@ import {
   timestamp,
   unique,
   uniqueIndex,
+  index,
   check,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core"
@@ -133,23 +134,45 @@ export const submissions = pgTable(
   ],
 )
 
-// An immutable audit trail of edits made to a submitted submission (US-5.2):
-// one row per edit, capturing the full prior data snapshot so a full history
-// of who changed what and when can be reconstructed, mirroring how
-// form_versions never mutates a published row in place.
-export const submissionEdits = pgTable("submission_edits", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  submissionId: uuid("submission_id")
-    .notNull()
-    .references(() => submissions.id, { onDelete: "cascade" }),
-  // The submission's data immediately before this edit was applied, so the
-  // edit history can show what changed rather than just that it did.
-  previousData: jsonb("previous_data").notNull(),
-  // Freeform identifier of who made this edit, mirroring `submittedBy` and
-  // `publishedBy` above -- there's no auth/user system yet, so this is
-  // whatever the caller supplies rather than a foreign key to a users table.
-  editedBy: text("edited_by"),
-  editedAt: timestamp("edited_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-})
+// An immutable audit trail of edits made to a submitted submission (US-5.2,
+// US-6.1): one row per edit, capturing a full snapshot of the row as it
+// stood immediately before the edit applied. Populated by a Postgres
+// `BEFORE UPDATE` trigger on `submissions` (see the
+// submission_archive_trigger migration) rather than application code, so
+// the archive step can never be skipped by a code path that updates
+// `submissions` directly, and so it shares the row-level lock Postgres
+// already takes for the `UPDATE` itself -- closing the race a purely
+// app-level SELECT-then-INSERT-then-UPDATE would be exposed to.
+export const submissionHistory = pgTable(
+  "submission_history",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    submissionId: uuid("submission_id")
+      .notNull()
+      .references(() => submissions.id, { onDelete: "cascade" }),
+    // Denormalized snapshot of the row's own fields at archive time,
+    // mirroring `submissions` itself.
+    formId: uuid("form_id").notNull(),
+    formVersionId: uuid("form_version_id").notNull(),
+    data: jsonb("data").notNull(),
+    legacyData: jsonb("legacy_data"),
+    status: text("status", { enum: ["draft", "submitted"] }).notNull(),
+    submittedBy: text("submitted_by"),
+    migratedFromSubmissionId: uuid("migrated_from_submission_id"),
+    // Freeform identifier of who made this edit, mirroring `submittedBy` and
+    // `publishedBy` above -- there's no auth/user system yet, so this is
+    // whatever the caller supplies rather than a foreign key to a users
+    // table. Captured by the trigger via a transaction-local Postgres
+    // setting (`app.edited_by`), since a trigger has no direct access to
+    // application-level call arguments.
+    editedBy: text("edited_by"),
+    // SCD Type 2 columns: the window during which this snapshot was the
+    // live row's value. `activeFrom` is the superseded row's own
+    // `updated_at`; `activeTo` is when the archiving UPDATE ran.
+    activeFrom: timestamp("active_from", { withTimezone: true }).notNull(),
+    activeTo: timestamp("active_to", { withTimezone: true }).notNull(),
+  },
+  (table) => [
+    index("submission_history_submission_id").on(table.submissionId),
+  ],
+)

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,14 +1,14 @@
-import { and, desc, eq, gte, lte } from "drizzle-orm"
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
 import {
   formVersions,
-  submissionEdits,
+  submissionHistory,
   submissions,
 } from "../../../db/schema.js"
 import type {
   CreateMigratedInput,
   SubmissionDetailRow,
-  SubmissionEditRow,
+  SubmissionHistoryRow,
   SubmissionListFilters,
   SubmissionRow,
   SubmissionsRepository,
@@ -171,9 +171,16 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
     editedBy?: string | null,
   ): Promise<SubmissionRow | null> {
     return this.db.transaction(async (tx) => {
-      const [existing] = await tx
-        .select({ data: submissions.data })
-        .from(submissions)
+      // Transaction-local: read by the archive trigger via
+      // current_setting('app.edited_by', true), since a trigger has no
+      // direct access to this call's arguments.
+      await tx.execute(
+        sql`select set_config('app.edited_by', ${editedBy ?? ""}, true)`,
+      )
+
+      const [updated] = await tx
+        .update(submissions)
+        .set({ data, updatedAt: new Date() })
         .where(
           and(
             eq(submissions.id, submissionId),
@@ -181,35 +188,29 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
             eq(submissions.status, "submitted"),
           ),
         )
-      if (!existing) return null
-
-      await tx.insert(submissionEdits).values({
-        submissionId,
-        previousData: existing.data,
-        editedBy: editedBy ?? null,
-      })
-
-      const [updated] = await tx
-        .update(submissions)
-        .set({ data, updatedAt: new Date() })
-        .where(eq(submissions.id, submissionId))
         .returning(SUBMISSION_COLUMNS)
-      return updated
+      return updated ?? null
     })
   }
 
-  async listEdits(submissionId: string): Promise<SubmissionEditRow[]> {
+  async listHistory(submissionId: string): Promise<SubmissionHistoryRow[]> {
     return this.db
       .select({
-        id: submissionEdits.id,
-        submissionId: submissionEdits.submissionId,
-        previousData: submissionEdits.previousData,
-        editedBy: submissionEdits.editedBy,
-        editedAt: submissionEdits.editedAt,
+        id: submissionHistory.id,
+        submissionId: submissionHistory.submissionId,
+        formVersionId: submissionHistory.formVersionId,
+        data: submissionHistory.data,
+        legacyData: submissionHistory.legacyData,
+        status: submissionHistory.status,
+        submittedBy: submissionHistory.submittedBy,
+        migratedFromSubmissionId: submissionHistory.migratedFromSubmissionId,
+        editedBy: submissionHistory.editedBy,
+        activeFrom: submissionHistory.activeFrom,
+        activeTo: submissionHistory.activeTo,
       })
-      .from(submissionEdits)
-      .where(eq(submissionEdits.submissionId, submissionId))
-      .orderBy(desc(submissionEdits.editedAt))
+      .from(submissionHistory)
+      .where(eq(submissionHistory.submissionId, submissionId))
+      .orderBy(desc(submissionHistory.activeTo))
   }
 
   async createMigrated(input: CreateMigratedInput): Promise<SubmissionRow> {

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -49,12 +49,18 @@ export interface SubmissionDetailRow extends SubmissionRow {
   schema: unknown
 }
 
-export interface SubmissionEditRow {
+export interface SubmissionHistoryRow {
   id: string
   submissionId: string
-  previousData: unknown
+  formVersionId: string
+  data: unknown
+  legacyData: unknown
+  status: "draft" | "submitted"
+  submittedBy: string | null
+  migratedFromSubmissionId: string | null
   editedBy: string | null
-  editedAt: Date
+  activeFrom: Date
+  activeTo: Date
 }
 
 export interface SubmissionsRepository {
@@ -117,11 +123,13 @@ export interface SubmissionsRepository {
     submissionId: string,
   ): Promise<SubmissionDetailRow | null>
 
-  // Overwrites a submitted submission's data in place and records the prior
-  // data as an audit-trail row in the same operation (US-5.2), so the two
-  // can never happen independently. Returns null if the row doesn't exist,
-  // belongs to a different form, or is still a draft (edits apply only to
-  // already-submitted submissions -- a draft is edited via saveDraft).
+  // Overwrites a submitted submission's data in place (US-5.2). The prior
+  // row state is archived as an audit-trail row by a database trigger as
+  // part of the same UPDATE (US-6.1), so the two can never happen
+  // independently or race each other. Returns null if the row doesn't
+  // exist, belongs to a different form, or is still a draft (edits apply
+  // only to already-submitted submissions -- a draft is edited via
+  // saveDraft).
   edit(
     formId: string,
     submissionId: string,
@@ -129,8 +137,9 @@ export interface SubmissionsRepository {
     editedBy?: string | null,
   ): Promise<SubmissionRow | null>
 
-  // The edit history for one submission, most recent first (US-5.2).
-  listEdits(submissionId: string): Promise<SubmissionEditRow[]>
+  // The archived history for one submission, most recently superseded
+  // first (US-5.2, US-6.1).
+  listHistory(submissionId: string): Promise<SubmissionHistoryRow[]>
 
   // Records a submission produced by migrating another one onto a newer
   // version (US-6.1). The source submission is never touched -- this always

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -9,7 +9,7 @@ import {
   MigrationResultSchema,
   SaveDraftSubmissionSchema,
   SubmissionDetailSchema,
-  SubmissionEditListSchema,
+  SubmissionHistoryListSchema,
   SubmissionListQuerySchema,
   SubmissionListSchema,
   SubmissionSchema,
@@ -26,7 +26,7 @@ import {
 } from "./services/submissions.js"
 import type {
   SubmissionDetailRow,
-  SubmissionEditRow,
+  SubmissionHistoryRow,
   SubmissionRow,
 } from "./repositories/submissions.js"
 import type { SubmissionsService } from "./services/submissions.js"
@@ -57,11 +57,13 @@ function serializeDetail(submission: SubmissionDetailRow) {
   }
 }
 
-function serializeEdit(edit: SubmissionEditRow) {
+function serializeHistoryEntry(entry: SubmissionHistoryRow) {
   return {
-    ...edit,
-    previousData: edit.previousData as Record<string, unknown>,
-    editedAt: edit.editedAt.toISOString(),
+    ...entry,
+    data: entry.data as Record<string, unknown>,
+    legacyData: (entry.legacyData as Record<string, unknown> | null) ?? null,
+    activeFrom: entry.activeFrom.toISOString(),
+    activeTo: entry.activeTo.toISOString(),
   }
 }
 
@@ -280,18 +282,18 @@ export function submissionsPlugin(
     )
 
     typed.get(
-      "/api/forms/:formId/submissions/:submissionId/edits",
+      "/api/forms/:formId/submissions/:submissionId/history",
       {
         schema: {
           params: SubmissionParamsSchema,
-          response: { 200: SubmissionEditListSchema },
+          response: { 200: SubmissionHistoryListSchema },
         },
       },
       async (request) => {
-        const edits = await service.getEditHistory(
+        const history = await service.getHistory(
           request.params.submissionId,
         )
-        return edits.map(serializeEdit)
+        return history.map(serializeHistoryEntry)
       },
     )
 

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -138,7 +138,8 @@ export class SubmissionsService {
   // against -- not the form's current active version, which may since have
   // changed or been republished -- so an edit can never be rejected (or
   // wrongly accepted) against rules that didn't apply when it was captured.
-  // Records the prior data as an audit-trail row in the same operation.
+  // The prior row state is archived as an audit-trail row by a database
+  // trigger as part of the same UPDATE (US-6.1).
   async edit(
     formId: string,
     submissionId: string,
@@ -160,9 +161,10 @@ export class SubmissionsService {
     return edited
   }
 
-  // The full edit history for one submission, most recent first (US-5.2).
-  getEditHistory(submissionId: string) {
-    return this.repo.listEdits(submissionId)
+  // The full audit-trail history for one submission, most recently
+  // superseded first (US-5.2, US-6.1).
+  getHistory(submissionId: string) {
+    return this.repo.listHistory(submissionId)
   }
 
   // Computes the diff an admin needs to decide a migration plan for

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -53,8 +53,8 @@ export {
   SubmissionListQuerySchema,
   SubmissionDetailSchema,
   EditSubmissionSchema,
-  SubmissionEditSchema,
-  SubmissionEditListSchema,
+  SubmissionHistorySchema,
+  SubmissionHistoryListSchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
@@ -65,7 +65,7 @@ export type {
   SubmissionListQuery,
   SubmissionDetail,
   EditSubmission,
-  SubmissionEdit,
+  SubmissionHistory,
   SubmissionValidationError,
 } from "./schemas/submission.js"
 export {

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -99,19 +99,27 @@ export const EditSubmissionSchema = z.object({
 
 export type EditSubmission = z.infer<typeof EditSubmissionSchema>
 
-// One row of a submission's edit history (US-5.2): the data as it stood
-// immediately before that edit was applied, plus who made it and when.
-export const SubmissionEditSchema = z.object({
+// One row of a submission's audit-trail history (US-5.2, US-6.1): a full
+// snapshot of the submission as it stood during [activeFrom, activeTo),
+// archived by a database trigger the moment an edit superseded it (SCD
+// Type 2), plus who made that edit.
+export const SubmissionHistorySchema = z.object({
   id: z.string(),
   submissionId: z.string(),
-  previousData: z.record(z.string(), z.unknown()),
+  formVersionId: z.string(),
+  data: z.record(z.string(), z.unknown()),
+  legacyData: z.record(z.string(), z.unknown()).nullable(),
+  status: z.enum(["draft", "submitted"]),
+  submittedBy: z.string().nullable(),
+  migratedFromSubmissionId: z.string().nullable(),
   editedBy: z.string().nullable(),
-  editedAt: z.iso.datetime(),
+  activeFrom: z.iso.datetime(),
+  activeTo: z.iso.datetime(),
 })
 
-export type SubmissionEdit = z.infer<typeof SubmissionEditSchema>
+export type SubmissionHistory = z.infer<typeof SubmissionHistorySchema>
 
-export const SubmissionEditListSchema = z.array(SubmissionEditSchema)
+export const SubmissionHistoryListSchema = z.array(SubmissionHistorySchema)
 
 // Returned when required fields are missing at submission time (US-3.5).
 export const SubmissionValidationErrorSchema = z.object({


### PR DESCRIPTION
## Summary
- Replaces the app-level `submission_edits` audit table with a real SCD Type 2 mechanism enforced by the database: a `submission_history` table (with `activeFrom`/`activeTo`) populated by a Postgres `BEFORE UPDATE` trigger on `submissions`.
- Archiving now happens as part of the `UPDATE` statement itself, so it can never be skipped by a future code path that updates `submissions.data` directly, and it shares Postgres's own row-level lock on the target row — closing the concurrent-edit race the old app-level `SELECT`-then-`INSERT`-then-`UPDATE` flow was exposed to.
- `editedBy` is threaded through to the trigger via a transaction-local `set_config('app.edited_by', ...)` call, since a trigger has no direct access to the calling code's arguments.
- Renamed the corresponding shared/server/client contracts (`SubmissionEditSchema` → `SubmissionHistorySchema`, `GET .../edits` → `GET .../history`, etc).
- Per ADR-0004, no trigger was added to `form_versions` — a published version's row is never mutated in place, so there's nothing to archive there.

Closes richard-orchard-rewa/formbuilder#54.

## Test plan
- [x] `npm run typecheck`, `npm run build`, `npm audit --omit=dev` all pass
- [x] Manual SQL verification against a throwaway Postgres container: drafts are excluded from archiving, `editedBy` is captured correctly, and two concurrent edits genuinely serialize (the second blocks until the first commits, then archives the first's *committed* value rather than a stale read)
- [x] Full Playwright e2e suite passes against an isolated DB, including the submit → edit → history-UI flow
- [ ] `npm test` (Vitest) has pre-existing, unrelated failures in `FieldInspector.test.tsx`/`FormPreview.test.tsx` in this environment (an "Invalid hook call" React duplication issue) — confirmed unrelated since neither file is touched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)