### PR TITLE
US-6.3: view submission history (timeline list)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { FormFill } from "./FormFill.js"
 import { MigrationPlanner } from "./MigrationPlanner.js"
 import { RendererSpike } from "./renderer-spike/RendererSpike.js"
 import { SubmissionEdit } from "./SubmissionEdit.js"
+import { SubmissionHistory } from "./SubmissionHistory.js"
 import { SubmissionList } from "./SubmissionList.js"
 import { SubmissionView } from "./SubmissionView.js"
 
@@ -16,6 +17,7 @@ type View =
   | { mode: "submissions"; form: FormSummary }
   | { mode: "view-submission"; form: FormSummary; submissionId: string }
   | { mode: "edit-submission"; form: FormSummary; submissionId: string }
+  | { mode: "submission-history"; form: FormSummary; submissionId: string }
   | {
       mode: "migrate"
       form: FormSummary
@@ -107,13 +109,28 @@ export function App() {
   }
 
   if (view.mode === "view-submission") {
-    const { form } = view
+    const { form, submissionId } = view
     return (
       <SubmissionView
         formId={form.id}
         formName={form.name}
-        submissionId={view.submissionId}
+        submissionId={submissionId}
         onBack={() => setView({ mode: "submissions", form })}
+        onViewHistory={() =>
+          setView({ mode: "submission-history", form, submissionId })
+        }
+      />
+    )
+  }
+
+  if (view.mode === "submission-history") {
+    const { form, submissionId } = view
+    return (
+      <SubmissionHistory
+        formId={form.id}
+        formName={form.name}
+        submissionId={submissionId}
+        onBack={() => setView({ mode: "view-submission", form, submissionId })}
       />
     )
   }

--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -9,6 +9,7 @@ import {
   SubmissionRejectedError,
 } from "./api.js"
 import { formCells } from "./schema/formCells.js"
+import { SubmissionHistoryList } from "./SubmissionHistoryList.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface SubmissionEditProps {
@@ -71,8 +72,6 @@ export function SubmissionEdit({
     [submission],
   )
 
-  const pastVersions = history.slice(0, -1)
-
   async function handleSave() {
     if (errors.length > 0) {
       setShowValidation(true)
@@ -132,20 +131,7 @@ export function SubmissionEdit({
           </button>
 
           <h2>Edit history</h2>
-          {/* getSubmissionHistory returns every version including the
-              current one (activeTo: null) at the end -- that's not itself
-              an edit event, so it's excluded from this list. */}
-          {pastVersions.length === 0 && <p>No edits yet.</p>}
-          {pastVersions.length > 0 && (
-            <ul>
-              {pastVersions.map((entry) => (
-                <li key={entry.id}>
-                  {entry.activeTo && new Date(entry.activeTo).toLocaleString()}
-                  {entry.editedBy && ` — ${entry.editedBy}`}
-                </li>
-              ))}
-            </ul>
-          )}
+          <SubmissionHistoryList versions={history} />
         </>
       )}
     </main>

--- a/client/src/SubmissionHistory.tsx
+++ b/client/src/SubmissionHistory.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react"
+import type { SubmissionHistory as SubmissionHistoryEntry } from "shared"
+import { getSubmissionHistory } from "./api.js"
+import { SubmissionHistoryList } from "./SubmissionHistoryList.js"
+
+interface SubmissionHistoryProps {
+  formId: string
+  formName: string
+  submissionId: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// Lets an admin see that a submission was edited before digging into what
+// changed (US-6.3): a timeline of its previous versions, most recent first,
+// with who changed it and when. Reachable from the submission detail
+// screen (SubmissionView).
+export function SubmissionHistory({
+  formId,
+  formName,
+  submissionId,
+  onBack,
+}: SubmissionHistoryProps) {
+  const [versions, setVersions] = useState<SubmissionHistoryEntry[]>([])
+  const [status, setStatus] = useState<Status>("loading")
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getSubmissionHistory(formId, submissionId)
+      .then((result) => {
+        if (cancelled) return
+        setVersions(result)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId, submissionId])
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Submission history</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load this submission's history.</p>
+      )}
+      {status === "ready" && <SubmissionHistoryList versions={versions} />}
+    </main>
+  )
+}

--- a/client/src/SubmissionHistoryList.tsx
+++ b/client/src/SubmissionHistoryList.tsx
@@ -1,0 +1,34 @@
+import type { SubmissionHistory } from "shared"
+
+interface SubmissionHistoryListProps {
+  versions: SubmissionHistory[]
+}
+
+// Renders the previous versions of a submission as a timeline, most recent
+// edit first (US-6.3): when it was superseded and who did it. `versions` is
+// the full lifetime list returned by getSubmissionHistory, including the
+// current still-live entry (`activeTo: null`) -- that one isn't a "previous
+// version" so it's excluded here.
+export function SubmissionHistoryList({ versions }: SubmissionHistoryListProps) {
+  const previousVersions = versions
+    .filter(
+      (version): version is SubmissionHistory & { activeTo: string } =>
+        version.activeTo !== null,
+    )
+    .reverse()
+
+  if (previousVersions.length === 0) {
+    return <p>No edits yet.</p>
+  }
+
+  return (
+    <ul>
+      {previousVersions.map((version) => (
+        <li key={version.id}>
+          {new Date(version.activeTo).toLocaleString()}
+          {version.editedBy && ` — ${version.editedBy}`}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/client/src/SubmissionView.tsx
+++ b/client/src/SubmissionView.tsx
@@ -11,6 +11,7 @@ interface SubmissionViewProps {
   formName: string
   submissionId: string
   onBack: () => void
+  onViewHistory: () => void
 }
 
 type Status = "loading" | "ready" | "error"
@@ -24,6 +25,7 @@ export function SubmissionView({
   formName,
   submissionId,
   onBack,
+  onViewHistory,
 }: SubmissionViewProps) {
   const [submission, setSubmission] = useState<SubmissionDetail | null>(null)
   const [status, setStatus] = useState<Status>("loading")
@@ -57,6 +59,9 @@ export function SubmissionView({
           ← Back
         </button>
         <h1>{formName} — Submission</h1>
+        <button type="button" onClick={onViewHistory}>
+          History
+        </button>
       </header>
 
       {status === "loading" && <p>Loading…</p>}

--- a/e2e/tests/form-lifecycle.spec.ts
+++ b/e2e/tests/form-lifecycle.spec.ts
@@ -75,4 +75,15 @@ test("create, build, publish, submit, and edit a form", async ({
 
   await expect(page.getByText("Saved.")).toBeVisible()
   await expect(page.getByText(/No edits yet\./)).not.toBeVisible()
+
+  // History: the timeline of previous versions is reachable from the
+  // submission detail screen (US-6.3), most recent edit first.
+  await page.getByRole("button", { name: "← Back" }).click()
+  await submissionRow.getByRole("button", { name: "View" }).click()
+  await page.getByRole("button", { name: "History" }).click()
+  await expect(
+    page.getByRole("heading", { name: `${formName} — Submission history` }),
+  ).toBeVisible()
+  await expect(page.getByText(/No edits yet\./)).not.toBeVisible()
+  await expect(page.locator("ul li")).toHaveCount(1)
 })


### PR DESCRIPTION
## Summary
- Adds a "History" button on the submission detail screen (`SubmissionView`) that opens a new `SubmissionHistory` screen: a timeline of the submission's previous versions, most recent edit first, each showing when it was superseded and who did it.
- Extracted the list-rendering logic into a shared `SubmissionHistoryList` component so it isn't duplicated between the new history screen and the existing inline "Edit history" list on the edit screen — the edit screen's list is now also most-recent-first, for consistency (previously ascending, an implementation detail from US-6.2's work rather than a deliberate UX choice).
- Extended `e2e/tests/form-lifecycle.spec.ts` to cover the new flow: after editing a submission, navigate to its detail screen, open History, and confirm the previous version shows up.

Stacked on richard-orchard-rewa/formbuilder#59 (US-6.2) since this depends on the `getSubmissionHistory` endpoint built there — this PR targets that branch rather than `main`, and should be retargeted once the chain (#58 → #59 → this) merges in order.

Closes richard-orchard-rewa/formbuilder#56.

## Test plan
- [x] `npm run typecheck`, `npm run build`, `npm audit --omit=dev` all pass
- [x] Full Playwright e2e suite passes against an isolated DB, including the new History-view assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)