### PR TITLE
Land US-6.2 and US-6.3 into main

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { FormFill } from "./FormFill.js"
 import { MigrationPlanner } from "./MigrationPlanner.js"
 import { RendererSpike } from "./renderer-spike/RendererSpike.js"
 import { SubmissionEdit } from "./SubmissionEdit.js"
+import { SubmissionHistory } from "./SubmissionHistory.js"
 import { SubmissionList } from "./SubmissionList.js"
 import { SubmissionView } from "./SubmissionView.js"
 
@@ -16,6 +17,7 @@ type View =
   | { mode: "submissions"; form: FormSummary }
   | { mode: "view-submission"; form: FormSummary; submissionId: string }
   | { mode: "edit-submission"; form: FormSummary; submissionId: string }
+  | { mode: "submission-history"; form: FormSummary; submissionId: string }
   | {
       mode: "migrate"
       form: FormSummary
@@ -107,13 +109,28 @@ export function App() {
   }
 
   if (view.mode === "view-submission") {
-    const { form } = view
+    const { form, submissionId } = view
     return (
       <SubmissionView
         formId={form.id}
         formName={form.name}
-        submissionId={view.submissionId}
+        submissionId={submissionId}
         onBack={() => setView({ mode: "submissions", form })}
+        onViewHistory={() =>
+          setView({ mode: "submission-history", form, submissionId })
+        }
+      />
+    )
+  }
+
+  if (view.mode === "submission-history") {
+    const { form, submissionId } = view
+    return (
+      <SubmissionHistory
+        formId={form.id}
+        formName={form.name}
+        submissionId={submissionId}
+        onBack={() => setView({ mode: "view-submission", form, submissionId })}
       />
     )
   }

--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -71,6 +71,8 @@ export function SubmissionEdit({
     [submission],
   )
 
+  const pastVersions = history.slice(0, -1)
+
   async function handleSave() {
     if (errors.length > 0) {
       setShowValidation(true)
@@ -130,12 +132,15 @@ export function SubmissionEdit({
           </button>
 
           <h2>Edit history</h2>
-          {history.length === 0 && <p>No edits yet.</p>}
-          {history.length > 0 && (
+          {/* getSubmissionHistory returns every version including the
+              current one (activeTo: null) at the end -- that's not itself
+              an edit event, so it's excluded from this list. */}
+          {pastVersions.length === 0 && <p>No edits yet.</p>}
+          {pastVersions.length > 0 && (
             <ul>
-              {history.map((entry) => (
+              {pastVersions.map((entry) => (
                 <li key={entry.id}>
-                  {new Date(entry.activeTo).toLocaleString()}
+                  {entry.activeTo && new Date(entry.activeTo).toLocaleString()}
                   {entry.editedBy && ` — ${entry.editedBy}`}
                 </li>
               ))}

--- a/client/src/SubmissionEdit.tsx
+++ b/client/src/SubmissionEdit.tsx
@@ -9,6 +9,7 @@ import {
   SubmissionRejectedError,
 } from "./api.js"
 import { formCells } from "./schema/formCells.js"
+import { SubmissionHistoryList } from "./SubmissionHistoryList.js"
 import { toJsonSchema } from "./schema/toJsonSchema.js"
 
 interface SubmissionEditProps {
@@ -71,8 +72,6 @@ export function SubmissionEdit({
     [submission],
   )
 
-  const pastVersions = history.slice(0, -1)
-
   async function handleSave() {
     if (errors.length > 0) {
       setShowValidation(true)
@@ -132,20 +131,7 @@ export function SubmissionEdit({
           </button>
 
           <h2>Edit history</h2>
-          {/* getSubmissionHistory returns every version including the
-              current one (activeTo: null) at the end -- that's not itself
-              an edit event, so it's excluded from this list. */}
-          {pastVersions.length === 0 && <p>No edits yet.</p>}
-          {pastVersions.length > 0 && (
-            <ul>
-              {pastVersions.map((entry) => (
-                <li key={entry.id}>
-                  {entry.activeTo && new Date(entry.activeTo).toLocaleString()}
-                  {entry.editedBy && ` — ${entry.editedBy}`}
-                </li>
-              ))}
-            </ul>
-          )}
+          <SubmissionHistoryList versions={history} />
         </>
       )}
     </main>

--- a/client/src/SubmissionHistory.tsx
+++ b/client/src/SubmissionHistory.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react"
+import type { SubmissionHistory as SubmissionHistoryEntry } from "shared"
+import { getSubmissionHistory } from "./api.js"
+import { SubmissionHistoryList } from "./SubmissionHistoryList.js"
+
+interface SubmissionHistoryProps {
+  formId: string
+  formName: string
+  submissionId: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// Lets an admin see that a submission was edited before digging into what
+// changed (US-6.3): a timeline of its previous versions, most recent first,
+// with who changed it and when. Reachable from the submission detail
+// screen (SubmissionView).
+export function SubmissionHistory({
+  formId,
+  formName,
+  submissionId,
+  onBack,
+}: SubmissionHistoryProps) {
+  const [versions, setVersions] = useState<SubmissionHistoryEntry[]>([])
+  const [status, setStatus] = useState<Status>("loading")
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getSubmissionHistory(formId, submissionId)
+      .then((result) => {
+        if (cancelled) return
+        setVersions(result)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId, submissionId])
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Submission history</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load this submission's history.</p>
+      )}
+      {status === "ready" && <SubmissionHistoryList versions={versions} />}
+    </main>
+  )
+}

--- a/client/src/SubmissionHistoryList.tsx
+++ b/client/src/SubmissionHistoryList.tsx
@@ -1,0 +1,34 @@
+import type { SubmissionHistory } from "shared"
+
+interface SubmissionHistoryListProps {
+  versions: SubmissionHistory[]
+}
+
+// Renders the previous versions of a submission as a timeline, most recent
+// edit first (US-6.3): when it was superseded and who did it. `versions` is
+// the full lifetime list returned by getSubmissionHistory, including the
+// current still-live entry (`activeTo: null`) -- that one isn't a "previous
+// version" so it's excluded here.
+export function SubmissionHistoryList({ versions }: SubmissionHistoryListProps) {
+  const previousVersions = versions
+    .filter(
+      (version): version is SubmissionHistory & { activeTo: string } =>
+        version.activeTo !== null,
+    )
+    .reverse()
+
+  if (previousVersions.length === 0) {
+    return <p>No edits yet.</p>
+  }
+
+  return (
+    <ul>
+      {previousVersions.map((version) => (
+        <li key={version.id}>
+          {new Date(version.activeTo).toLocaleString()}
+          {version.editedBy && ` — ${version.editedBy}`}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/client/src/SubmissionView.tsx
+++ b/client/src/SubmissionView.tsx
@@ -11,6 +11,7 @@ interface SubmissionViewProps {
   formName: string
   submissionId: string
   onBack: () => void
+  onViewHistory: () => void
 }
 
 type Status = "loading" | "ready" | "error"
@@ -24,6 +25,7 @@ export function SubmissionView({
   formName,
   submissionId,
   onBack,
+  onViewHistory,
 }: SubmissionViewProps) {
   const [submission, setSubmission] = useState<SubmissionDetail | null>(null)
   const [status, setStatus] = useState<Status>("loading")
@@ -57,6 +59,9 @@ export function SubmissionView({
           ← Back
         </button>
         <h1>{formName} — Submission</h1>
+        <button type="button" onClick={onViewHistory}>
+          History
+        </button>
       </header>
 
       {status === "loading" && <p>Loading…</p>}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -201,8 +201,8 @@ export async function editSubmission(
   return json<Submission>(res)
 }
 
-// The audit-trail history for one submission, most recently superseded
-// first (US-5.2, US-6.1).
+// Every version of one submission, oldest first, ending with the current
+// one (US-5.2, US-6.1, US-6.2).
 export function getSubmissionHistory(
   formId: string,
   submissionId: string,

--- a/e2e/tests/form-lifecycle.spec.ts
+++ b/e2e/tests/form-lifecycle.spec.ts
@@ -75,4 +75,15 @@ test("create, build, publish, submit, and edit a form", async ({
 
   await expect(page.getByText("Saved.")).toBeVisible()
   await expect(page.getByText(/No edits yet\./)).not.toBeVisible()
+
+  // History: the timeline of previous versions is reachable from the
+  // submission detail screen (US-6.3), most recent edit first.
+  await page.getByRole("button", { name: "← Back" }).click()
+  await submissionRow.getByRole("button", { name: "View" }).click()
+  await page.getByRole("button", { name: "History" }).click()
+  await expect(
+    page.getByRole("heading", { name: `${formName} — Submission history` }),
+  ).toBeVisible()
+  await expect(page.getByText(/No edits yet\./)).not.toBeVisible()
+  await expect(page.locator("ul li")).toHaveCount(1)
 })

--- a/server/src/modules/submissions/repositories/submissions.drizzle.ts
+++ b/server/src/modules/submissions/repositories/submissions.drizzle.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, lte, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm"
 import type { Db } from "../../../db/client.js"
 import {
   formVersions,
@@ -193,24 +193,63 @@ export class DrizzleSubmissionsRepository implements SubmissionsRepository {
     })
   }
 
-  async listHistory(submissionId: string): Promise<SubmissionHistoryRow[]> {
-    return this.db
-      .select({
-        id: submissionHistory.id,
-        submissionId: submissionHistory.submissionId,
-        formVersionId: submissionHistory.formVersionId,
-        data: submissionHistory.data,
-        legacyData: submissionHistory.legacyData,
-        status: submissionHistory.status,
-        submittedBy: submissionHistory.submittedBy,
-        migratedFromSubmissionId: submissionHistory.migratedFromSubmissionId,
-        editedBy: submissionHistory.editedBy,
-        activeFrom: submissionHistory.activeFrom,
-        activeTo: submissionHistory.activeTo,
-      })
-      .from(submissionHistory)
-      .where(eq(submissionHistory.submissionId, submissionId))
-      .orderBy(desc(submissionHistory.activeTo))
+  async listVersions(submissionId: string): Promise<SubmissionHistoryRow[]> {
+    const [archived, [current]] = await Promise.all([
+      this.db
+        .select({
+          id: submissionHistory.id,
+          submissionId: submissionHistory.submissionId,
+          formVersionId: submissionHistory.formVersionId,
+          data: submissionHistory.data,
+          legacyData: submissionHistory.legacyData,
+          status: submissionHistory.status,
+          submittedBy: submissionHistory.submittedBy,
+          migratedFromSubmissionId: submissionHistory.migratedFromSubmissionId,
+          editedBy: submissionHistory.editedBy,
+          activeFrom: submissionHistory.activeFrom,
+          activeTo: submissionHistory.activeTo,
+        })
+        .from(submissionHistory)
+        .where(eq(submissionHistory.submissionId, submissionId))
+        .orderBy(asc(submissionHistory.activeFrom)),
+      this.db
+        .select({
+          id: submissions.id,
+          formVersionId: submissions.formVersionId,
+          data: submissions.data,
+          legacyData: submissions.legacyData,
+          status: submissions.status,
+          submittedBy: submissions.submittedBy,
+          migratedFromSubmissionId: submissions.migratedFromSubmissionId,
+          activeFrom: submissions.updatedAt,
+        })
+        .from(submissions)
+        .where(eq(submissions.id, submissionId)),
+    ])
+
+    if (!current) return archived
+
+    // The edit that most recently closed out an archived version is the
+    // same edit that produced the current one -- there's no separate
+    // record of "who made the current version" otherwise.
+    const producedBy = archived.at(-1)?.editedBy ?? null
+
+    return [
+      ...archived,
+      {
+        id: current.id,
+        submissionId,
+        formVersionId: current.formVersionId,
+        data: current.data,
+        legacyData: current.legacyData,
+        status: current.status,
+        submittedBy: current.submittedBy,
+        migratedFromSubmissionId: current.migratedFromSubmissionId,
+        editedBy: producedBy,
+        activeFrom: current.activeFrom,
+        activeTo: null,
+      },
+    ]
   }
 
   async createMigrated(input: CreateMigratedInput): Promise<SubmissionRow> {

--- a/server/src/modules/submissions/repositories/submissions.ts
+++ b/server/src/modules/submissions/repositories/submissions.ts
@@ -49,6 +49,8 @@ export interface SubmissionDetailRow extends SubmissionRow {
   schema: unknown
 }
 
+// One version of a submission across its lifetime (US-6.1, US-6.2).
+// `activeTo` is null for the current, still-live version.
 export interface SubmissionHistoryRow {
   id: string
   submissionId: string
@@ -60,7 +62,7 @@ export interface SubmissionHistoryRow {
   migratedFromSubmissionId: string | null
   editedBy: string | null
   activeFrom: Date
-  activeTo: Date
+  activeTo: Date | null
 }
 
 export interface SubmissionsRepository {
@@ -137,9 +139,12 @@ export interface SubmissionsRepository {
     editedBy?: string | null,
   ): Promise<SubmissionRow | null>
 
-  // The archived history for one submission, most recently superseded
-  // first (US-5.2, US-6.1).
-  listHistory(submissionId: string): Promise<SubmissionHistoryRow[]>
+  // Every version of one submission across its lifetime, oldest first,
+  // ending with the current still-live one (`activeTo: null`) (US-5.2,
+  // US-6.1, US-6.2) -- so a point-in-time "what did this look like on date
+  // X" query can be answered by finding the entry whose
+  // [activeFrom, activeTo) window contains X.
+  listVersions(submissionId: string): Promise<SubmissionHistoryRow[]>
 
   // Records a submission produced by migrating another one onto a newer
   // version (US-6.1). The source submission is never touched -- this always

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -9,7 +9,9 @@ import {
   MigrationResultSchema,
   SaveDraftSubmissionSchema,
   SubmissionDetailSchema,
+  SubmissionHistoryAtQuerySchema,
   SubmissionHistoryListSchema,
+  SubmissionHistorySchema,
   SubmissionListQuerySchema,
   SubmissionListSchema,
   SubmissionSchema,
@@ -63,7 +65,7 @@ function serializeHistoryEntry(entry: SubmissionHistoryRow) {
     data: entry.data as Record<string, unknown>,
     legacyData: (entry.legacyData as Record<string, unknown> | null) ?? null,
     activeFrom: entry.activeFrom.toISOString(),
-    activeTo: entry.activeTo.toISOString(),
+    activeTo: entry.activeTo?.toISOString() ?? null,
   }
 }
 
@@ -281,6 +283,8 @@ export function submissionsPlugin(
       },
     )
 
+    // Every version of the submission, oldest first, ending with the
+    // current one (US-6.2).
     typed.get(
       "/api/forms/:formId/submissions/:submissionId/history",
       {
@@ -290,10 +294,38 @@ export function submissionsPlugin(
         },
       },
       async (request) => {
-        const history = await service.getHistory(
+        const versions = await service.getVersions(
           request.params.submissionId,
         )
-        return history.map(serializeHistoryEntry)
+        return versions.map(serializeHistoryEntry)
+      },
+    )
+
+    // The version of the submission active at a specific point in time
+    // (US-6.2) -- "what did this look like on date X".
+    typed.get(
+      "/api/forms/:formId/submissions/:submissionId/history/at",
+      {
+        schema: {
+          params: SubmissionParamsSchema,
+          querystring: SubmissionHistoryAtQuerySchema,
+          response: {
+            200: SubmissionHistorySchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        const version = await service.getVersionAt(
+          request.params.submissionId,
+          new Date(request.query.asOf),
+        )
+        if (!version) {
+          return reply.code(404).send({
+            message: `No version of submission ${request.params.submissionId} was active at ${request.query.asOf}`,
+          })
+        }
+        return reply.code(200).send(serializeHistoryEntry(version))
       },
     )
 

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -161,10 +161,25 @@ export class SubmissionsService {
     return edited
   }
 
-  // The full audit-trail history for one submission, most recently
-  // superseded first (US-5.2, US-6.1).
-  getHistory(submissionId: string) {
-    return this.repo.listHistory(submissionId)
+  // Every version of one submission across its lifetime, oldest first,
+  // including the current one (US-5.2, US-6.1, US-6.2).
+  getVersions(submissionId: string) {
+    return this.repo.listVersions(submissionId)
+  }
+
+  // The version of a submission that was active at a specific point in
+  // time (US-6.2) -- "what did this look like on date X" -- or null if
+  // `asOf` predates the submission's own creation. `activeTo: null` (the
+  // current version) is treated as an open-ended window extending to now.
+  async getVersionAt(submissionId: string, asOf: Date) {
+    const versions = await this.repo.listVersions(submissionId)
+    return (
+      versions.find(
+        (version) =>
+          version.activeFrom <= asOf &&
+          (version.activeTo === null || asOf < version.activeTo),
+      ) ?? null
+    )
   }
 
   // Computes the diff an admin needs to decide a migration plan for

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -55,6 +55,7 @@ export {
   EditSubmissionSchema,
   SubmissionHistorySchema,
   SubmissionHistoryListSchema,
+  SubmissionHistoryAtQuerySchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
@@ -66,6 +67,7 @@ export type {
   SubmissionDetail,
   EditSubmission,
   SubmissionHistory,
+  SubmissionHistoryAtQuery,
   SubmissionValidationError,
 } from "./schemas/submission.js"
 export {

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -99,10 +99,12 @@ export const EditSubmissionSchema = z.object({
 
 export type EditSubmission = z.infer<typeof EditSubmissionSchema>
 
-// One row of a submission's audit-trail history (US-5.2, US-6.1): a full
-// snapshot of the submission as it stood during [activeFrom, activeTo),
+// One version of a submission across its lifetime (US-5.2, US-6.1, US-6.2):
+// a full snapshot of the data as it stood during [activeFrom, activeTo),
 // archived by a database trigger the moment an edit superseded it (SCD
-// Type 2), plus who made that edit.
+// Type 2), plus who made the edit that produced it. `activeTo` is null for
+// the current, still-live version -- every earlier one was closed out by a
+// later edit and always has one.
 export const SubmissionHistorySchema = z.object({
   id: z.string(),
   submissionId: z.string(),
@@ -114,12 +116,23 @@ export const SubmissionHistorySchema = z.object({
   migratedFromSubmissionId: z.string().nullable(),
   editedBy: z.string().nullable(),
   activeFrom: z.iso.datetime(),
-  activeTo: z.iso.datetime(),
+  activeTo: z.iso.datetime().nullable(),
 })
 
 export type SubmissionHistory = z.infer<typeof SubmissionHistorySchema>
 
 export const SubmissionHistoryListSchema = z.array(SubmissionHistorySchema)
+
+// Point-in-time lookup (US-6.2): which version of a submission was active
+// at `asOf`, per the SCD Type 2 design -- "what did this look like on date
+// X".
+export const SubmissionHistoryAtQuerySchema = z.object({
+  asOf: z.iso.datetime(),
+})
+
+export type SubmissionHistoryAtQuery = z.infer<
+  typeof SubmissionHistoryAtQuerySchema
+>
 
 // Returned when required fields are missing at submission time (US-3.5).
 export const SubmissionValidationErrorSchema = z.object({


### PR DESCRIPTION
## Summary
Pure follow-up, no new code: richard-orchard-rewa/formbuilder#59 (US-6.2) and richard-orchard-rewa/formbuilder#60 (US-6.3) were opened stacked on richard-orchard-rewa/formbuilder#58's branch (per this repo's convention for work that builds on a still-open PR), each noting they'd need retargeting to `main` once the chain landed. #58 merged into `main`, but #59 and #60 were merged into their stacked parent branches instead of being retargeted — so `main` is currently missing US-6.2 (the `/history` and `/history/at` endpoints) and US-6.3 (the history timeline UI), even though both PRs show as merged.

This PR is exactly the two already-reviewed commits from #59 and #60, brought onto the current `main`, with no changes.

## Test plan
- [x] `npm run typecheck`, `npm run build`, `npm audit --omit=dev` all pass (already verified when #59/#60 were opened; no code changed here)
- [x] Diff is identical to #59 + #60 combined — nothing new to re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)