### PR TITLE
US-6.4: view a specific past version (read-only)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { RendererSpike } from "./renderer-spike/RendererSpike.js"
 import { SubmissionEdit } from "./SubmissionEdit.js"
 import { SubmissionHistory } from "./SubmissionHistory.js"
 import { SubmissionList } from "./SubmissionList.js"
+import { SubmissionVersionView } from "./SubmissionVersionView.js"
 import { SubmissionView } from "./SubmissionView.js"
 
 type View =
@@ -18,6 +19,12 @@ type View =
   | { mode: "view-submission"; form: FormSummary; submissionId: string }
   | { mode: "edit-submission"; form: FormSummary; submissionId: string }
   | { mode: "submission-history"; form: FormSummary; submissionId: string }
+  | {
+      mode: "submission-version"
+      form: FormSummary
+      submissionId: string
+      versionId: string
+    }
   | {
       mode: "migrate"
       form: FormSummary
@@ -131,6 +138,22 @@ export function App() {
         formName={form.name}
         submissionId={submissionId}
         onBack={() => setView({ mode: "view-submission", form, submissionId })}
+        onSelectVersion={(versionId) =>
+          setView({ mode: "submission-version", form, submissionId, versionId })
+        }
+      />
+    )
+  }
+
+  if (view.mode === "submission-version") {
+    const { form, submissionId, versionId } = view
+    return (
+      <SubmissionVersionView
+        formId={form.id}
+        formName={form.name}
+        submissionId={submissionId}
+        versionId={versionId}
+        onBack={() => setView({ mode: "submission-history", form, submissionId })}
       />
     )
   }

--- a/client/src/SubmissionHistory.tsx
+++ b/client/src/SubmissionHistory.tsx
@@ -8,6 +8,7 @@ interface SubmissionHistoryProps {
   formName: string
   submissionId: string
   onBack: () => void
+  onSelectVersion: (versionId: string) => void
 }
 
 type Status = "loading" | "ready" | "error"
@@ -21,6 +22,7 @@ export function SubmissionHistory({
   formName,
   submissionId,
   onBack,
+  onSelectVersion,
 }: SubmissionHistoryProps) {
   const [versions, setVersions] = useState<SubmissionHistoryEntry[]>([])
   const [status, setStatus] = useState<Status>("loading")
@@ -55,7 +57,9 @@ export function SubmissionHistory({
       {status === "error" && (
         <p role="alert">Couldn't load this submission's history.</p>
       )}
-      {status === "ready" && <SubmissionHistoryList versions={versions} />}
+      {status === "ready" && (
+        <SubmissionHistoryList versions={versions} onSelect={onSelectVersion} />
+      )}
     </main>
   )
 }

--- a/client/src/SubmissionHistoryList.tsx
+++ b/client/src/SubmissionHistoryList.tsx
@@ -2,6 +2,10 @@ import type { SubmissionHistory } from "shared"
 
 interface SubmissionHistoryListProps {
   versions: SubmissionHistory[]
+  // Opens one previous version read-only (US-6.4). Optional -- the inline
+  // list on the edit screen doesn't offer this, only the dedicated history
+  // screen does.
+  onSelect?: (versionId: string) => void
 }
 
 // Renders the previous versions of a submission as a timeline, most recent
@@ -9,7 +13,10 @@ interface SubmissionHistoryListProps {
 // the full lifetime list returned by getSubmissionHistory, including the
 // current still-live entry (`activeTo: null`) -- that one isn't a "previous
 // version" so it's excluded here.
-export function SubmissionHistoryList({ versions }: SubmissionHistoryListProps) {
+export function SubmissionHistoryList({
+  versions,
+  onSelect,
+}: SubmissionHistoryListProps) {
   const previousVersions = versions
     .filter(
       (version): version is SubmissionHistory & { activeTo: string } =>
@@ -23,12 +30,25 @@ export function SubmissionHistoryList({ versions }: SubmissionHistoryListProps) 
 
   return (
     <ul>
-      {previousVersions.map((version) => (
-        <li key={version.id}>
-          {new Date(version.activeTo).toLocaleString()}
-          {version.editedBy && ` — ${version.editedBy}`}
-        </li>
-      ))}
+      {previousVersions.map((version) => {
+        const label = (
+          <>
+            {new Date(version.activeTo).toLocaleString()}
+            {version.editedBy && ` — ${version.editedBy}`}
+          </>
+        )
+        return (
+          <li key={version.id}>
+            {onSelect ? (
+              <button type="button" onClick={() => onSelect(version.id)}>
+                {label}
+              </button>
+            ) : (
+              label
+            )}
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/client/src/SubmissionVersionView.tsx
+++ b/client/src/SubmissionVersionView.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from "react"
+import { JsonForms } from "@jsonforms/react"
+import { vanillaRenderers } from "@jsonforms/vanilla-renderers"
+import type { SubmissionHistoryDetail } from "shared"
+import { getSubmissionVersion } from "./api.js"
+import { formCells } from "./schema/formCells.js"
+import { toJsonSchema } from "./schema/toJsonSchema.js"
+
+interface SubmissionVersionViewProps {
+  formId: string
+  formName: string
+  submissionId: string
+  versionId: string
+  onBack: () => void
+}
+
+type Status = "loading" | "ready" | "error"
+
+// Opens one specific past version of a submission, read-only, rendered
+// against the exact form schema that was active when that version was
+// captured (US-6.4). Reachable only from the history timeline
+// (SubmissionHistoryList) -- there is no edit or restore action here, and
+// the banner below makes clear this isn't the current live version.
+export function SubmissionVersionView({
+  formId,
+  formName,
+  submissionId,
+  versionId,
+  onBack,
+}: SubmissionVersionViewProps) {
+  const [version, setVersion] = useState<SubmissionHistoryDetail | null>(null)
+  const [status, setStatus] = useState<Status>("loading")
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus("loading")
+    getSubmissionVersion(formId, submissionId, versionId)
+      .then((result) => {
+        if (cancelled) return
+        setVersion(result)
+        setStatus("ready")
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("error")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [formId, submissionId, versionId])
+
+  const { schema, uiSchema } = useMemo(
+    () => toJsonSchema(version?.schema ?? { fields: [] }),
+    [version],
+  )
+
+  return (
+    <main className="form-fill">
+      <header className="form-builder__header">
+        <button type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <h1>{formName} — Historical version</h1>
+      </header>
+
+      {status === "loading" && <p>Loading…</p>}
+      {status === "error" && (
+        <p role="alert">Couldn't load this version.</p>
+      )}
+
+      {status === "ready" && version && (
+        <>
+          <p role="status">
+            Historical version, active{" "}
+            {new Date(version.activeFrom).toLocaleString()}
+            {version.activeTo &&
+              ` – ${new Date(version.activeTo).toLocaleString()}`}
+            {version.editedBy && ` — edited by ${version.editedBy}`}. Not the
+            current version. Read-only.
+          </p>
+          <JsonForms
+            schema={schema}
+            uischema={uiSchema}
+            data={version.data}
+            renderers={vanillaRenderers}
+            cells={formCells}
+            readonly
+          />
+        </>
+      )}
+    </main>
+  )
+}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -10,6 +10,7 @@ import type {
   Submission,
   SubmissionDetail,
   SubmissionHistory,
+  SubmissionHistoryDetail,
   SubmissionListQuery,
   SubmissionSummary,
   SubmissionValidationError,
@@ -210,6 +211,19 @@ export function getSubmissionHistory(
   return fetch(`/api/forms/${formId}/submissions/${submissionId}/history`).then(
     (res) => json<SubmissionHistory[]>(res),
   )
+}
+
+// One specific version of a submission -- current or past -- with the exact
+// schema it was active against, so it renders correctly regardless of how
+// the form has since changed (US-6.4).
+export function getSubmissionVersion(
+  formId: string,
+  submissionId: string,
+  versionId: string,
+): Promise<SubmissionHistoryDetail> {
+  return fetch(
+    `/api/forms/${formId}/submissions/${submissionId}/history/${versionId}`,
+  ).then((res) => json<SubmissionHistoryDetail>(res))
 }
 
 // The diff between two form versions an admin needs in order to build a

--- a/e2e/tests/form-lifecycle.spec.ts
+++ b/e2e/tests/form-lifecycle.spec.ts
@@ -86,4 +86,15 @@ test("create, build, publish, submit, and edit a form", async ({
   ).toBeVisible()
   await expect(page.getByText(/No edits yet\./)).not.toBeVisible()
   await expect(page.locator("ul li")).toHaveCount(1)
+
+  // Viewing a past version (US-6.4): read-only, clearly labelled
+  // historical, showing the pre-edit value rather than the current one.
+  await page.locator("ul li button").click()
+  await expect(
+    page.getByRole("heading", { name: `${formName} — Historical version` }),
+  ).toBeVisible()
+  await expect(page.getByRole("status")).toContainText("Historical version")
+  await expect(page.getByRole("status")).toContainText("Read-only")
+  await expect(page.getByLabel(/Full name/)).toHaveValue("Ada Lovelace")
+  await expect(page.getByLabel(/Full name/)).toBeDisabled()
 })

--- a/server/src/modules/submissions/routes.ts
+++ b/server/src/modules/submissions/routes.ts
@@ -10,6 +10,7 @@ import {
   SaveDraftSubmissionSchema,
   SubmissionDetailSchema,
   SubmissionHistoryAtQuerySchema,
+  SubmissionHistoryDetailSchema,
   SubmissionHistoryListSchema,
   SubmissionHistorySchema,
   SubmissionListQuerySchema,
@@ -37,6 +38,9 @@ const FormParamsSchema = z.object({ formId: z.string() })
 const SubmissionParamsSchema = z.object({
   formId: z.string(),
   submissionId: z.string(),
+})
+const SubmissionVersionParamsSchema = SubmissionParamsSchema.extend({
+  versionId: z.string(),
 })
 const ErrorResponseSchema = z.object({ message: z.string() })
 
@@ -66,6 +70,18 @@ function serializeHistoryEntry(entry: SubmissionHistoryRow) {
     legacyData: (entry.legacyData as Record<string, unknown> | null) ?? null,
     activeFrom: entry.activeFrom.toISOString(),
     activeTo: entry.activeTo?.toISOString() ?? null,
+  }
+}
+
+function serializeHistoryDetail(
+  entry: SubmissionHistoryRow & { formVersionNumber: number; schema: unknown },
+) {
+  return {
+    ...serializeHistoryEntry(entry),
+    formVersionNumber: entry.formVersionNumber,
+    // The jsonb column is untyped at the DB layer; the app is the only
+    // writer and always writes the FormSchema shape.
+    schema: entry.schema as FormSchema,
   }
 }
 
@@ -326,6 +342,43 @@ export function submissionsPlugin(
           })
         }
         return reply.code(200).send(serializeHistoryEntry(version))
+      },
+    )
+
+    // One specific version of the submission -- current or past -- with the
+    // exact schema it was active against, read-only (US-6.4). Registered
+    // after the more specific /history/at path so Fastify's router doesn't
+    // treat "at" as a :versionId value.
+    typed.get(
+      "/api/forms/:formId/submissions/:submissionId/history/:versionId",
+      {
+        schema: {
+          params: SubmissionVersionParamsSchema,
+          response: {
+            200: SubmissionHistoryDetailSchema,
+            404: ErrorResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        try {
+          const version = await service.getVersionDetail(
+            request.params.formId,
+            request.params.submissionId,
+            request.params.versionId,
+          )
+          if (!version) {
+            return reply.code(404).send({
+              message: `No version ${request.params.versionId} found for submission ${request.params.submissionId}`,
+            })
+          }
+          return reply.code(200).send(serializeHistoryDetail(version))
+        } catch (error) {
+          if (error instanceof FormVersionNotFoundError) {
+            return reply.code(404).send({ message: error.message })
+          }
+          throw error
+        }
       },
     )
 

--- a/server/src/modules/submissions/services/submissions.ts
+++ b/server/src/modules/submissions/services/submissions.ts
@@ -182,6 +182,37 @@ export class SubmissionsService {
     )
   }
 
+  // One specific past (or current) version of a submission, plus the exact
+  // schema (and version number) that was active at its `activeFrom` (US-6.4)
+  // -- so a historical version always renders correctly even if the form
+  // has since been republished with a different structure, mirroring
+  // getById's approach for the current version. Scoped to `formId` the same
+  // way getById is. Returns null if the submission doesn't exist, belongs
+  // to a different form, or `versionId` doesn't match any of its versions.
+  async getVersionDetail(
+    formId: string,
+    submissionId: string,
+    versionId: string,
+  ) {
+    const submission = await this.repo.getById(formId, submissionId)
+    if (!submission) return null
+
+    const versions = await this.repo.listVersions(submissionId)
+    const version = versions.find((candidate) => candidate.id === versionId)
+    if (!version) return null
+
+    const formVersion = await this.formVersions.getVersionById(
+      version.formVersionId,
+    )
+    if (!formVersion) throw new FormVersionNotFoundError(version.formVersionId)
+
+    return {
+      ...version,
+      formVersionNumber: formVersion.version,
+      schema: formVersion.schema,
+    }
+  }
+
   // Computes the diff an admin needs to decide a migration plan for
   // (US-6.1): which of `fromVersionId`'s fields carry over to
   // `targetVersionId` under the same id, and which need an explicit

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -56,6 +56,7 @@ export {
   SubmissionHistorySchema,
   SubmissionHistoryListSchema,
   SubmissionHistoryAtQuerySchema,
+  SubmissionHistoryDetailSchema,
   SubmissionValidationErrorSchema,
 } from "./schemas/submission.js"
 export type {
@@ -68,6 +69,7 @@ export type {
   EditSubmission,
   SubmissionHistory,
   SubmissionHistoryAtQuery,
+  SubmissionHistoryDetail,
   SubmissionValidationError,
 } from "./schemas/submission.js"
 export {

--- a/shared/src/schemas/submission.ts
+++ b/shared/src/schemas/submission.ts
@@ -123,6 +123,19 @@ export type SubmissionHistory = z.infer<typeof SubmissionHistorySchema>
 
 export const SubmissionHistoryListSchema = z.array(SubmissionHistorySchema)
 
+// One version of a submission plus the exact schema (and version number)
+// that was active at its `activeFrom` (US-6.4), so a historical version
+// always renders correctly -- mirroring SubmissionDetailSchema's approach
+// for the current version.
+export const SubmissionHistoryDetailSchema = SubmissionHistorySchema.extend({
+  formVersionNumber: z.number().int(),
+  schema: FormSchemaSchema,
+})
+
+export type SubmissionHistoryDetail = z.infer<
+  typeof SubmissionHistoryDetailSchema
+>
+
 // Point-in-time lookup (US-6.2): which version of a submission was active
 // at `asOf`, per the SCD Type 2 design -- "what did this look like on date
 // X".


### PR DESCRIPTION
## Summary
- Adds `GET /api/forms/:formId/submissions/:submissionId/history/:versionId`, returning one specific version (current or past) of a submission plus the exact form schema (and version number) that was active at its `activeFrom` -- mirroring how the existing submission-detail endpoint joins in the schema for the current version.
- New `SubmissionVersionView` client screen, reachable by clicking an entry in the history timeline (US-6.3): renders the historical data read-only via JsonForms, with a status banner naming the active window, who made the edit, and explicitly stating it's historical/read-only and not the current version. No restore/rollback action, per the AC.
- Turned each `SubmissionHistoryList` entry into a button (`onSelect` prop, optional so the edit screen's inline list is unaffected) to drive the new navigation.
- Extended `e2e/tests/form-lifecycle.spec.ts`: after opening the history timeline, clicks the one past entry and confirms the historical screen shows the pre-edit value with the field disabled and the read-only labelling present.

Stacked on richard-orchard-rewa/formbuilder#61, which lands the US-6.2/US-6.3 work that was merged into a stacked branch instead of `main` -- this PR should be retargeted to `main` once #61 merges.

Closes richard-orchard-rewa/formbuilder#57.

## Test plan
- [x] `npm run typecheck`, `npm run build`, `npm audit --omit=dev` all pass
- [x] Full Playwright e2e suite passes against an isolated DB, including the new click-into-history-entry assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)